### PR TITLE
fix: browser.getSource can be sync

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -106,7 +106,7 @@ class WebdriverPercy {
         });
       }
       return new Promise((resolve, reject) => {
-        browserInstance.getSource().then((source) => {
+        Promise.resolve(browserInstance.getSource()).then((source) => {
           percy.createBuild.then((buildId) => {
             const rootResource = percyClient.makeResource({
               resourceUrl: '/',


### PR DESCRIPTION
In webdriverio 4.4.0 and also in [the docs](http://webdriver.io/api/property/getSource.html) the `.getSource()` call is synchronous, so we need to wrap this call in a `Promise.resolve`