### PR TITLE
Run travis with latest deps too

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,11 @@ cache:
     - "node_modules"
 node_js:
   - "6"
+env:
+  - YARN_OPTS=
+  - YARN_OPTS=--no-lockfile
 install:
-  yarn
+  yarn install $YARN_OPTS
 script:
   - npm run lint
   - npm run build


### PR DESCRIPTION
See #7 adds a new travis config that does ignores yarn.lock so we CI against latests deps as well