### PR TITLE
Raise if no asset dir

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "percy-webdriverio",
+  "name": "@percy-io/percy-webdriverio",
   "version": "0.1.0",
   "description": "percy.io integration for webdriver.io",
   "main": "dist/main.js",

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/main.js",
   "scripts": {
     "build": "babel src --presets babel-preset-es2015 --out-dir dist",
-    "lint": "eslint ./src",
+    "lint": "eslint ./src ./test/specs",
     "test": "cd test/specs && wdio",
     "prepublish": "babel src --presets babel-preset-es2015 --out-dir dist",
     "prepare": "babel src --presets babel-preset-es2015 --out-dir dist"

--- a/src/fileSystemAssetLoader.js
+++ b/src/fileSystemAssetLoader.js
@@ -12,46 +12,70 @@ export default class FileSystemAssetLoader {
     this.options = options;
   }
   findSnapshotResources(page, percyClient) {
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       const options = this.options;
       const buildDir = options.buildDir;
       const mountPath = `${(options.mountPath || '')}/`;
 
-      const resources = [];
-      walk.walkSync(buildDir, {
-        followLinks: true,
-        listeners: {
-          file: function file(root, fileStats, next) {
-            const absolutePath = path.join(root, fileStats.name);
-            let resourceUrl = absolutePath.replace(buildDir, '');
-            if (path.sep === '\\') {
-              // Windows support: transform filesystem backslashes into forward-slashes for the URL.
-              resourceUrl = resourceUrl.replace('\\', '/');
-            }
-            if (resourceUrl.charAt(0) === '/') {
-              resourceUrl = resourceUrl.substr(1);
-            }
-            for (const assetPattern of options.skippedAssets) {
-              if (resourceUrl.match(assetPattern)) {
-                next();
+      let isDirectory = false;
+      try {
+        isDirectory = fs.statSync(buildDir).isDirectory();
+      } catch (err) {
+        console.log("[xx] stat failed!");
+        reject(err);
+        return;
+      }
+
+      if (isDirectory) {
+        console.log("[xx] is directory!")
+        const resources = [];
+        let errors;
+        walk.walkSync(buildDir, {
+          followLinks: true,
+          listeners: {
+            file: function file(root, fileStats, next) {
+              const absolutePath = path.join(root, fileStats.name);
+              let resourceUrl = absolutePath.replace(buildDir, '');
+              if (path.sep === '\\') {
+                // Windows support: transform filesystem backslashes into forward-slashes for the URL.
+                resourceUrl = resourceUrl.replace('\\', '/');
+              }
+              if (resourceUrl.charAt(0) === '/') {
+                resourceUrl = resourceUrl.substr(1);
+              }
+              for (const assetPattern of options.skippedAssets) {
+                if (resourceUrl.match(assetPattern)) {
+                  next();
+                  return;
+                }
+              }
+              if (fs.statSync(absolutePath).size > MAX_FILE_SIZE_BYTES) {
+                console.warn('\n[percy][WARNING] Skipping large file: ', resourceUrl); // eslint-disable-line no-console
                 return;
               }
+              const content = fs.readFileSync(absolutePath);
+              resources.push(percyClient.makeResource({
+                resourceUrl: encodeURI(`${mountPath}${resourceUrl}`),
+                content,
+                mimetype: mime.lookup(resourceUrl)
+              }));
+              next();
+            },
+            errors: function handleErrors(root, fileStats, next) {
+              errors = fileStats;
+              next();
             }
-            if (fs.statSync(absolutePath).size > MAX_FILE_SIZE_BYTES) {
-              console.warn('\n[percy][WARNING] Skipping large file: ', resourceUrl); // eslint-disable-line no-console
-              return;
-            }
-            const content = fs.readFileSync(absolutePath);
-            resources.push(percyClient.makeResource({
-              resourceUrl: encodeURI(`${mountPath}${resourceUrl}`),
-              content,
-              mimetype: mime.lookup(resourceUrl)
-            }));
-            next();
           }
+        });
+        if (resources.length === 0 && errors) {
+          reject(errors);
+        } else {
+          resolve(resources);
         }
-      });
-      resolve(resources);
+      } else {
+        console.log("[xxx] reject");
+        reject(`${buildDir} is not a directory`);
+      }
     });
   }
 }

--- a/src/fileSystemAssetLoader.js
+++ b/src/fileSystemAssetLoader.js
@@ -21,13 +21,11 @@ export default class FileSystemAssetLoader {
       try {
         isDirectory = fs.statSync(buildDir).isDirectory();
       } catch (err) {
-        console.log("[xx] stat failed!");
         reject(err);
         return;
       }
 
       if (isDirectory) {
-        console.log("[xx] is directory!")
         const resources = [];
         let errors;
         walk.walkSync(buildDir, {
@@ -73,7 +71,6 @@ export default class FileSystemAssetLoader {
           resolve(resources);
         }
       } else {
-        console.log("[xxx] reject");
         reject(`${buildDir} is not a directory`);
       }
     });

--- a/src/main.js
+++ b/src/main.js
@@ -144,6 +144,9 @@ class WebdriverPercy {
                     reject(err);
                   });
                 });
+            }).catch((err) => {
+              browser.logger.error(`percy snapshot failed to gatherSnapshotResources: ${err}`);
+              reject(err);
             });
           }).catch((err) => {
             browser.logger.error(`percy snapshot failed to createBuild: ${err}`);

--- a/test/specs/e2e_spec.js
+++ b/test/specs/e2e_spec.js
@@ -202,7 +202,6 @@ describe('filesystem asset loader', () => {
   });
 
   it('will raise if directory does not exists', () => {
-    console.log("[xx] does not exists")
     nock('https://percy.io:443').log(console.log); // eslint-disable-line no-console
     const buildId = '2967283';
     const snapshotId = '9499661';

--- a/test/specs/wdio.conf.js
+++ b/test/specs/wdio.conf.js
@@ -1,3 +1,7 @@
+/* eslint indent: ["error", 4] */
+/* eslint-disable object-shorthand, func-names, global-require */
+/* global browser */
+
 exports.config = {
 
     //
@@ -146,15 +150,15 @@ exports.config = {
      * @param {Object} config wdio configuration object
      * @param {Array.<Object>} capabilities list of capabilities details
      */
-    onPrepare: function (/*config, capabilities*/) {
-        if (process.env.NOCK_REC === "1") {
-          process.env.PERCY_TOKEN=process.env.REC_PERCY_TOKEN;
-          process.env.PERCY_PROJECT=process.env.REC_PRECY_PROJECT;
+    onPrepare: function (/* config, capabilities */) {
+        if (process.env.NOCK_REC === '1') {
+            process.env.PERCY_TOKEN = process.env.REC_PERCY_TOKEN;
+            process.env.PERCY_PROJECT = process.env.REC_PRECY_PROJECT;
         } else {
-          process.env.PERCY_PROJECT="dummy-repo/dummy-project";
+            process.env.PERCY_PROJECT = 'dummy-repo/dummy-project';
         }
-        process.env.PERCY_BRANCH = "master";
-     },
+        process.env.PERCY_BRANCH = 'master';
+    },
     /**
      * Gets executed just before initialising the webdriver session and test framework. It allows you
      * to manipulate configurations depending on the capability or spec.
@@ -170,9 +174,9 @@ exports.config = {
      * @param {Array.<Object>} capabilities list of capabilities details
      * @param {Array.<String>} specs List of spec file paths that are to be run
      */
-    before: function (capabilities, specs) {
-      require('../../dist/main.js').init(browser, {})
-    },
+    before: function (/* capabilities, specs */) {
+        require('../../dist/main.js').init(browser, {});
+    }
     //
     /**
      * Hook that gets executed before the suite starts
@@ -250,4 +254,4 @@ exports.config = {
      */
     // onComplete: function(exitCode) {
     // }
-}
+};


### PR DESCRIPTION
Original PR message from @mfazekas:
``` 
Raise an error during snapshot if percyUseAssetLoader is configured with a filesystem path that does not exists or not a directory

Unfortunately error handling in node-walk/walkSync is async, so hard to rely on - see https://git.daplie.com/Daplie/node-walk/issues/66 that's why and extra fs.statSync is added
```