### PR TITLE
Fix issue with finalize when no percySnapshot has been called

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -72,23 +72,30 @@ class WebdriverPercy {
       const percy = browser.percy;
       const percyClient = browser.percy.percyClient;
       return new Promise((resolve, reject) => {
-        percy.createBuild
-          .then(percyBuildId => {
-            percyClient
-              .finalizeBuild(percyBuildId)
-              .then(() => {
-                browser.logger.info(`percy finalizedBuild[${percyBuildId}]: ok`);
-                resolve(true);
-              })
-              .catch(err => {
-                browser.logger.error(`percy finalizedBuild[${percyBuildId}]: ${err}`);
-                reject(err);
-              });
-          })
-          .catch(err => {
-            browser.logger.error('percy finalizedBuild failed to get build id');
-            reject(err);
-          });
+        if (percy.createBuild === undefined) {
+          browser.logger.error(
+            '[percy webdriverio] no percySnapshot calls => ignoring finalizeBuild',
+          );
+          reject(new Error('No percySnapshot calls were issued'));
+        } else {
+          percy.createBuild
+            .then(percyBuildId => {
+              percyClient
+                .finalizeBuild(percyBuildId)
+                .then(() => {
+                  browser.logger.info(`percy finalizedBuild[${percyBuildId}]: ok`);
+                  resolve(true);
+                })
+                .catch(err => {
+                  browser.logger.error(`percy finalizedBuild[${percyBuildId}]: ${err}`);
+                  reject(err);
+                });
+            })
+            .catch(err => {
+              browser.logger.error('percy finalizedBuild failed to get build id');
+              reject(err);
+            });
+        }
       });
     });
 

--- a/test/specs/e2e_spec.js
+++ b/test/specs/e2e_spec.js
@@ -227,6 +227,21 @@ describe('WDIO with percy', () => {
   });
 });
 
+describe('corner case: no perctSnapshot invocations', () => {
+  it('will not call finalize', () => {
+    nock('https://percy.io:443').log(console.log); // eslint-disable-line no-console
+    new Nock();
+
+    const staticServerPort = 4567;
+    browser.__percyReinit();
+    browser.url(`localhost:${staticServerPort}/fixtures/index.html`);
+    assert.equal(browser.getTitle(), 'Hello world');
+    assert.throws(() => {
+      browser.percyFinalizeBuild();
+    }, /No percySnapshot calls were issued/);
+  });
+});
+
 describe('filesystem asset loader', () => {
   it('will use mountPath as root for assets', () => {
     nock('https://percy.io:443').log(console.log); // eslint-disable-line no-console


### PR DESCRIPTION
Fixes: #15 

Instead of `cannot read 'then' on undefined` we do  log error message with: `No percySnapshot calls were issued`