### PR TITLE
Make createBuild and finalizeBuild work with multiple workers (aka te…

### DIFF
--- a/src/fileSystemAssetLoader.js
+++ b/src/fileSystemAssetLoader.js
@@ -11,7 +11,7 @@ export default class FileSystemAssetLoader {
     this.options = options;
     this.options.skippedAssets = this.options.skippedAssets || DEFAULT_SKIPPED_ASSETS;
   }
-  findSnapshotResources(page, percyClient) {
+  findBuildResources(percyClient) {
     return new Promise((resolve, reject) => {
       const options = this.options;
       const buildDir = options.buildDir;


### PR DESCRIPTION
…st files)

Multiple worker means multiple processes, which meant we submitted multiple create+finalizeBuilds. unfortunately this is a breaking API change.

Example `wdio.conf.js`

```
onPrepare: function (config, capabilities) {
      var percy = require('@percy-io/percy-webdriverio');
      const assetLoaders = [percy.assetLoader('filesystem',{buildDir: 'static-assets', mountPath: ''})];
      return percy.createBuild(assetLoaders);
    }
...
onComplete: function(exitCode) {
      var percy = require('@percy-io/percy-webdriverio');
      return percy.finalizeBuild();
}    
```

this replaces use of `browser.percyUseAssetLoader, browser.percyFinalizeBuild`