### PR TITLE
Handle mountPath ending with /

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,4 @@ script:
 before_script:
   - "export DISPLAY=:99.0"
   - "sh -e /etc/init.d/xvfb start"
-  - sleep 3 # give xvfb some time to start
+  - sleep 5 # give xvfb some time to start

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "test": "cd test/specs && wdio",
     "precommit": "lint-staged",
     "prepublish": "babel src --out-dir dist",
-    "prepare": "babel src --out-dir dist"
+    "prepare": "babel src --out-dir dist",
+    "pretest": "babel src --out-dir dist"
   },
   "lint-staged": {
     "*.js": [

--- a/src/fileSystemAssetLoader.js
+++ b/src/fileSystemAssetLoader.js
@@ -16,8 +16,8 @@ export default class FileSystemAssetLoader {
       const options = this.options;
       const buildDir = options.buildDir;
 
-      // Setup the mountPath, and make sure it ends with one '/'
       let mountPath = `${options.mountPath || ''}`;
+      // Only add a / to the mountPath if it doesn't already end in one.
       if (mountPath.slice(-1) != '/') {
         mountPath = mountPath + '/';
       }

--- a/src/fileSystemAssetLoader.js
+++ b/src/fileSystemAssetLoader.js
@@ -15,7 +15,12 @@ export default class FileSystemAssetLoader {
     return new Promise((resolve, reject) => {
       const options = this.options;
       const buildDir = options.buildDir;
-      const mountPath = `${options.mountPath || ''}/`;
+
+      // Setup the mountPath, and make sure it ends with one '/'
+      let mountPath = `${options.mountPath || ''}`;
+      if (mountPath.slice(-1) != '/') {
+        mountPath = mountPath + '/';
+      }
 
       let isDirectory = false;
       try {

--- a/test/specs/e2e_spec.js
+++ b/test/specs/e2e_spec.js
@@ -325,6 +325,42 @@ describe('filesystem asset loader', () => {
     browser.sync_percy_finalizeBuild();
   });
 
+  it('will build correct resourceUrls when mountPath is /', () => {
+    nock('https://percy.io:443').log(console.log); // eslint-disable-line no-console
+    const buildId = '2967281';
+    const snapshotId = '94996612';
+    const pageSHA = '2733e50faa4486da67da7506edd34d6724b4fe7983f4b7d1015b62d228840e5e';
+    const appJSSHA = '2055335bf4ad0140b23abf5695f57dc9b9b336edf69b97511946a9beafa75cc6';
+    const appCSSSHA = 'ca00f77658989e0d71e3dfa552d33422cf28b12a15ba1c0195152845243e0d91';
+
+    const nmock = new Nock();
+    nmock.startBuild({
+      buildId,
+      resources: [
+        { id: appCSSSHA, url: '/app.css', mimetype: 'text/css' },
+        { id: appJSSHA, url: '/app.js', mimetype: 'application/javascript' },
+      ],
+    });
+    nmock.snapshot({
+      resources: [{ id: pageSHA, url: '/', mimetype: 'text/html', root: true }],
+      name: 'testPercy',
+      missing: [],
+      snapshotId,
+      buildId,
+    });
+    nmock.finalizeSnapshot({ snapshotId });
+    nmock.finalizeBuild({ buildId });
+
+    const staticServerPort = 4567;
+    percy.__reinit(browser);
+    browser.sync_percy_createBuild([
+      percy.assetLoader('filesystem', { buildDir: '../fixtures/assets', mountPath: '/' }),
+    ]);
+    browser.url(`localhost:${staticServerPort}/fixtures/index.html`);
+    browser.percySnapshot('testPercy');
+    browser.sync_percy_finalizeBuild();
+  });
+
   it('will raise if directory does not exists', () => {
     nock('https://percy.io:443').log(console.log); // eslint-disable-line no-console
     new Nock();


### PR DESCRIPTION
When you setup an assetLoader, one of the options is the mountPath.

Previously we always added a '/' to the end of the mountPath before using it as a prefix for the resourceUrl.  This leads to resourceUrls like '//app.css' if a mountPath of '/' was used.  

This PR modifies the logic to only add a '/' to the end of the mountPath if it doesn't already end in one, so we'd get a correct resourceURL of '/app.css'.

Story: https://app.clubhouse.io/percy/story/955/webdriver-fix-in-http-localhost-x-css-if-is-used-as-mountpath