### PR TITLE
Adding the ability to disable the percy snapshots using the env.

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,6 @@
     "babel-core": "^6.24.1",
     "babel-eslint": "^7.2.3",
     "babel-preset-env": "^1.6.0",
-    "babel-preset-es2015": "^6.24.1",
     "babel-register": "^6.26.0",
     "eslint": "^4.5.0",
     "eslint-config-prettier": "^2.3.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "babel-core": "^6.24.1",
     "babel-eslint": "^7.2.3",
     "babel-preset-env": "^1.6.0",
+    "babel-preset-es2015": "^6.24.1",
     "babel-register": "^6.26.0",
     "eslint": "^4.5.0",
     "eslint-config-prettier": "^2.3.0",

--- a/src/main.js
+++ b/src/main.js
@@ -170,8 +170,7 @@ function createPercyClient() {
 function isEnabled() {
   const hasRequiredVars = Boolean(process.env.PERCY_TOKEN) && Boolean(process.env.PERCY_PROJECT);
   const hasDisableVar = parseInt(process.env.PERCY_ENABLE) === 0;
-  const hasForceEnable = parseInt(process.env.PERCY_ENABLE) === 1;
-  return hasForceEnable || (hasRequiredVars && !hasDisableVar);
+  return hasRequiredVars && !hasDisableVar;
 }
 
 function logError(message) {

--- a/src/main.js
+++ b/src/main.js
@@ -82,7 +82,7 @@ class WebdriverPercy {
 
     browser.addCommand('percySnapshot', function async(name, options = {}) {
       if (!enabled) {
-        browser.logger.info('Percy disabled, skipping screenshot: ' + name);
+        browser.logger.info('Percy is disabled, skipping screenshot: ' + name);
         return;
       }
       const percy = browser.percy;

--- a/src/main.js
+++ b/src/main.js
@@ -168,7 +168,9 @@ function createPercyClient() {
 }
 
 function isEnabled() {
-  return parseInt(process.env.PERCY_ENABLE) !== 0;
+  const hasRequiredVars = Boolean(process.env.PERCY_TOKEN) && Boolean(process.env.PERCY_PROJECT);
+  const hasDisabledVar = parseInt(process.env.PERCY_ENABLE) === 0;
+  return hasRequiredVars && !hasDisabledVar;
 }
 
 function logError(message) {
@@ -222,7 +224,9 @@ export function __reinit(browser) {
 
 export function createBuild(assetLoaders) {
   if (!isEnabled()) {
-    logInfo('Percy disabled. `unset PERCY_ENABLE` to re-enable percy.');
+    logInfo(
+      'Percy disabled. Set the PERCY_TOKEN and PERCY_PROJECT and unset PERCY_ENABLE to re-enable Percy.',
+    );
     return new Promise(resolve => {
       resolve(null);
     });

--- a/src/main.js
+++ b/src/main.js
@@ -22,7 +22,8 @@ function gatherBuildResources(assetLoaders, percyClient) {
         resolve([].concat(...listOfResources));
       })
       .catch(err => {
-        console.log('[percy webdriverio] gatherBuildResources.XXX.reject', err); // eslint-disable-line no-console
+        // eslint-disable-next-line no-console
+        console.log('[percy webdriverio] gatherBuildResources.XXX.reject', err);
         reject(err);
       });
   });
@@ -52,6 +53,7 @@ class WebdriverPercy {
     }
     browser.percy = { assetLoaders: [] };
 
+    const enabled = isEnabled();
     const token = process.env.PERCY_TOKEN;
     const apiUrl = process.env.PERCY_API;
     const clientInfo = `percy-webdriverio ${version}`;
@@ -79,6 +81,10 @@ class WebdriverPercy {
     });
 
     browser.addCommand('percySnapshot', function async(name, options = {}) {
+      if (!enabled) {
+        browser.logger.info('Percy disabled, skipping screenshot: ' + name);
+        return;
+      }
       const percy = browser.percy;
       const browserInstance = this;
       const percyClient = percy.percyClient;
@@ -161,6 +167,10 @@ function createPercyClient() {
   return new PercyClient({ token, apiUrl, clientInfo });
 }
 
+function isEnabled() {
+  return parseInt(process.env.PERCY_ENABLE) !== 0;
+}
+
 function logError(message) {
   console.log(`[percy] ${message}`); // eslint-disable-line no-console
 }
@@ -180,6 +190,9 @@ function percyBuildId(caller) {
 }
 
 export function finalizeBuild() {
+  if (!isEnabled()) {
+    return;
+  }
   let percyClient = createPercyClient();
   return new Promise((resolve, reject) => {
     percyBuildId('finalizeBuild')
@@ -208,6 +221,12 @@ export function __reinit(browser) {
 }
 
 export function createBuild(assetLoaders) {
+  if (!isEnabled()) {
+    logInfo('Percy disabled. `unset PERCY_ENABLE` to re-enable percy.');
+    return new Promise(resolve => {
+      resolve(null);
+    });
+  }
   return new Promise((resolve, reject) => {
     let percyClient = createPercyClient();
     let environment = new Environment(process.env);

--- a/src/main.js
+++ b/src/main.js
@@ -169,8 +169,9 @@ function createPercyClient() {
 
 function isEnabled() {
   const hasRequiredVars = Boolean(process.env.PERCY_TOKEN) && Boolean(process.env.PERCY_PROJECT);
-  const hasDisabledVar = parseInt(process.env.PERCY_ENABLE) === 0;
-  return hasRequiredVars && !hasDisabledVar;
+  const hasDisableVar = parseInt(process.env.PERCY_ENABLE) === 0;
+  const hasForceEnable = parseInt(process.env.PERCY_ENABLE) === 1;
+  return hasForceEnable || (hasRequiredVars && !hasDisableVar);
 }
 
 function logError(message) {

--- a/test/specs/e2e_spec.js
+++ b/test/specs/e2e_spec.js
@@ -116,6 +116,8 @@ class Nock {
     }));
     const missingResources = (options.missing || []).map(sha => ({ type: 'resources', id: sha }));
     const commitSha = options.commitSha || browser.percy.environment.commitSha || null;
+    const pullRequestNumber =
+      options.pullRequestNumber || browser.percy.environment.pullRequestNumber || null;
     nock('https://percy.io:443', { encodedQueryParams: true })
       .post('/api/v1/projects/dummy-repo/dummy-project/builds/', {
         data: {
@@ -124,7 +126,7 @@ class Nock {
             branch: 'master',
             'target-branch': null,
             'commit-sha': commitSha,
-            'pull-request-number': null,
+            'pull-request-number': pullRequestNumber,
             'parallel-nonce': null,
             'parallel-total-shards': null,
           },

--- a/test/specs/e2e_spec.js
+++ b/test/specs/e2e_spec.js
@@ -115,6 +115,7 @@ class Nock {
       },
     }));
     const missingResources = (options.missing || []).map(sha => ({ type: 'resources', id: sha }));
+    const commitSha = options.commitSha || browser.percy.environment.commitSha || null;
     nock('https://percy.io:443', { encodedQueryParams: true })
       .post('/api/v1/projects/dummy-repo/dummy-project/builds/', {
         data: {
@@ -122,7 +123,7 @@ class Nock {
           attributes: {
             branch: 'master',
             'target-branch': null,
-            'commit-sha': null,
+            'commit-sha': commitSha,
             'pull-request-number': null,
             'parallel-nonce': null,
             'parallel-total-shards': null,

--- a/test/specs/e2e_spec.js
+++ b/test/specs/e2e_spec.js
@@ -119,7 +119,14 @@ class Nock {
       .post('/api/v1/projects/dummy-repo/dummy-project/builds/', {
         data: {
           type: 'builds',
-          attributes: { branch: 'master' },
+          attributes: {
+            branch: 'master',
+            'target-branch': null,
+            'commit-sha': null,
+            'pull-request-number': null,
+            'parallel-nonce': null,
+            'parallel-total-shards': null,
+          },
           relationships: { resources: { data: resources } },
         },
       })

--- a/test/specs/wdio.conf.js
+++ b/test/specs/wdio.conf.js
@@ -149,6 +149,7 @@ exports.config = {
       process.env.PERCY_TOKEN = process.env.REC_PERCY_TOKEN;
       process.env.PERCY_PROJECT = process.env.REC_PERCY_PROJECT;
     } else {
+      process.env.PERCY_ENABLE = '1';
       process.env.PERCY_PROJECT = 'dummy-repo/dummy-project';
     }
     process.env.PERCY_BRANCH = 'master';

--- a/test/specs/wdio.conf.js
+++ b/test/specs/wdio.conf.js
@@ -149,7 +149,7 @@ exports.config = {
       process.env.PERCY_TOKEN = process.env.REC_PERCY_TOKEN;
       process.env.PERCY_PROJECT = process.env.REC_PERCY_PROJECT;
     } else {
-      process.env.PERCY_ENABLE = '1';
+      process.env.PERCY_TOKEN = 'dummy-token';
       process.env.PERCY_PROJECT = 'dummy-repo/dummy-project';
     }
     process.env.PERCY_BRANCH = 'master';


### PR DESCRIPTION
`export PERCY_ENABLE=0` to disable percy screenshots or disabled if missing `PERCY_TOKEN` or `PERCY_PROJECT`.