### PR TITLE
Prevent warning from bluebird

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -85,7 +85,7 @@ class WebdriverPercy {
       return new Promise((resolve, reject) => {
         Promise.resolve(browserInstance.getSource())
           .then(source => {
-            percyBuildId('percySnapshot')
+            return percyBuildId('percySnapshot')
               .then(buildId => {
                 const rootResource = percyClient.makeResource({
                   resourceUrl: '/',


### PR DESCRIPTION
When using bluebird promise library with enabled warnings - it aims to detect mistakes when you don't return from the promise chain. In details its described here: http://goo.gl/rRqMUw

This change does not make difference in functionality, just prevents that warning.
```
(node:28419) Warning: a promise was created in a handler at Users/athli/Devel/printlovely/pl-api/client/node_modules/@percy-io/percy-webdriverio/dist/main.js:125:9 but was not returned from it, see http://goo.gl/rRqMUw
    at new Promise (/Users/athli/Devel/printlovely/pl-api/server/node_modules/bluebird/js/release/promise.js:79:10)
```