### PR TITLE
Add useful fields to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,5 +48,9 @@
     "webdriverio": "^4.8.0"
   },
   "author": "Miklós Fazekas",
-  "license": "MIT"
+  "license": "MIT",
+  "bugs": {
+    "url": "https://github.com/percy/percy-webdriverio/issues"
+  },
+  "repository": "https://github.com/percy/percy-webdriverio"
 }


### PR DESCRIPTION
This allows users to go to the repository from the npm page, and enables tools such as <https://greenkeeper.io> to track down the commit log for every package update.