### PR TITLE
Shift @percy-io/percy-webdriverio to publish to @percy/percy-webdriverio

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # percy-webdriverio
-[![Package Status](https://img.shields.io/npm/v/@percy-io/percy-webdriverio.svg)](https://www.npmjs.com/package/@percy-io/percy-webdriverio)
+[![Package Status](https://img.shields.io/npm/v/@percy/percy-webdriverio.svg)](https://www.npmjs.com/package/@percy/percy-webdriverio)
 [![Build Status](https://travis-ci.org/percy/percy-webdriverio.svg?branch=master)](https://travis-ci.org/percy/percy-webdriverio)
 
-**@percy-io/percy-webdriverio** adds [Percy](https://percy.io) visual testing and review to your [**WebdriverIO**](http://webdriver.io/) tests.
+**@percy/percy-webdriverio** adds [Percy](https://percy.io) visual testing and review to your [**WebdriverIO**](http://webdriver.io/) tests.
 
 #### Docs here: [https://percy.io/docs/clients/javascript/webdriverio](https://percy.io/docs/clients/javascript/webdriverio)
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -13,4 +13,4 @@
 1. Merge approved pull request
 1. Draft and publish a [new release on github](https://github.com/percy/percy-webdriverio/releases)
 1. `npm publish`
-1. [Visit NPM](https://www.npmjs.com/package/@percy-io/percy-webdriverio) and see that your version is now live.
+1. [Visit NPM](https://www.npmjs.com/package/@percy/percy-webdriverio) and see that your version is now live.

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@percy-io/percy-webdriverio",
+  "name": "@percy/percy-webdriverio",
   "version": "1.0.0",
   "description": "percy.io integration for webdriver.io",
   "main": "dist/index.js",


### PR DESCRIPTION
I will [npm deprecate](https://docs.npmjs.com/cli/deprecate) `@percy-io/percy-webdriverio` 0.2.0 and direct people to this new package name.