### PR TITLE
fix: require the SDK utils directly

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,8 +1,8 @@
 import fs from 'fs'
 import { clientInfo } from './environment'
-import { agentJsFilename, isAgentRunning, postSnapshot } from '@percy/agent'
+const { agentJsFilename, isAgentRunning, postSnapshot } = require('@percy/agent/dist/utils/sdk-utils')
 
-declare var PercyAgent: any;
+declare var PercyAgent: any
 
 /**
  * @param browser wdio Browser object that we are snapshotting. Required.
@@ -23,9 +23,9 @@ export async function percySnapshot(browser: BrowserObject, name: string, option
 
   await browser.executeScript(fs.readFileSync(agentJsFilename()).toString(), [])
 
-  const domSnapshot = await browser.execute(function (options: any) {
-    const percyAgentClient = new PercyAgent({ handleAgentCommunication: false });
-    return percyAgentClient.snapshot("unused", options);
+  const domSnapshot = await browser.execute((options: any) => {
+    const percyAgentClient = new PercyAgent({ handleAgentCommunication: false })
+    return percyAgentClient.snapshot('unused', options)
   }, options)
 
   await postDomSnapshot(name, domSnapshot, await browser.getUrl(), options)
@@ -37,9 +37,9 @@ async function postDomSnapshot(name: string, domSnapshot: any, url: string, opti
     url,
     domSnapshot,
     clientInfo: clientInfo(),
-    ...options
+    ...options,
   })
   if (!postSuccess) {
-    console.log(`[percy] Error posting snapshot to agent`)
+    console.log('[percy] Error posting snapshot to agent')
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -928,14 +928,39 @@
       }
     },
     "@wdio/sync": {
-      "version": "5.7.3",
-      "resolved": "https://registry.npmjs.org/@wdio/sync/-/sync-5.7.3.tgz",
-      "integrity": "sha512-WDlUGBVvwnfm0gYx395H2OZ6771q9s5yyCs5Q19gW+SarTVSvoKNKbbahifMTKmZAExMtSl8/Cm7jiW/U4E5Ew==",
+      "version": "5.7.9",
+      "resolved": "https://registry.npmjs.org/@wdio/sync/-/sync-5.7.9.tgz",
+      "integrity": "sha512-ee3G5Uti3vGe5lSXjucRSbQO6Rm8wrieyt+Tfix5/fDclDaqc9+SoK/TtgMwagzObBUXdJTtgv0HDrngqIUkeA==",
       "dev": true,
       "requires": {
-        "@wdio/config": "^5.7.3",
-        "@wdio/logger": "^5.7.0",
+        "@wdio/config": "^5.7.8",
+        "@wdio/logger": "^5.7.8",
         "fibers": "^3.1.1"
+      },
+      "dependencies": {
+        "@wdio/config": {
+          "version": "5.7.8",
+          "resolved": "https://registry.npmjs.org/@wdio/config/-/config-5.7.8.tgz",
+          "integrity": "sha512-XYx1OtJ/9iWk+s9svH1QmyKdWtOakK1o/0V7WBHBFQxR/iSpxRi3IyDPp2nnLTFz6T5eSipH4yS92bAJ1Q6XkQ==",
+          "dev": true,
+          "requires": {
+            "@wdio/logger": "^5.7.8",
+            "deepmerge": "^2.0.1",
+            "glob": "^7.1.2"
+          }
+        },
+        "@wdio/logger": {
+          "version": "5.7.8",
+          "resolved": "https://registry.npmjs.org/@wdio/logger/-/logger-5.7.8.tgz",
+          "integrity": "sha512-cbX/fHoTQ7xZvl8X4r828UjWv/ccKhpzPuNGZGukK2DRC7vSOg8sAi8bKNyjvv8nedaZkCQKaSFmsuHHlbIJ7g==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.3.0",
+            "loglevel": "^1.6.0",
+            "loglevel-plugin-prefix": "^0.5.3",
+            "strip-ansi": "^4.0.0"
+          }
+        }
       }
     },
     "@wdio/utils": {
@@ -2887,7 +2912,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -2908,12 +2934,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2928,17 +2956,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -3055,7 +3086,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -3067,6 +3099,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -3081,6 +3114,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -3088,12 +3122,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -3112,6 +3148,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -3192,7 +3229,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -3204,6 +3242,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -3289,7 +3328,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -3325,6 +3365,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -3344,6 +3385,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -3387,12 +3429,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },


### PR DESCRIPTION
Require these SDK util functions directly to avoid having to include them in the main `@percy/agent` bundle which causes issues as it mixes code that should go into the browser vs code that should run in node.

Bonus fixes: ran the linter and it applied some changes automatically.

Related issue: https://github.com/percy/percy-cypress/issues/58