### PR TITLE
fix: Use `browser.execute` over `browser.executeScript` for WebdriverIO v4 support

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -21,7 +21,7 @@ export async function percySnapshot(browser: BrowserObject, name: string, option
      return
   }
 
-  await browser.executeScript(fs.readFileSync(agentJsFilename()).toString(), [])
+  await browser.execute(fs.readFileSync(agentJsFilename()).toString(), [])
 
   const domSnapshot = await browser.execute((options: any) => {
     const percyAgentClient = new PercyAgent({ handleAgentCommunication: false })


### PR DESCRIPTION
## What is this?

A user came through support earlier with this error from the webdriver SDK:

```
TypeError: browser.executeScript is not a function
at [PATH]/@percy/webdriverio/dist/index.js:78:50
at step ([PATH]/@percy/webdriverio/dist/index.js:43:23)
at Object.next ([PATH]/@percy/webdriverio/dist/index.js:24:53)
at fulfilled ([PATH]/@percy/webdriverio/dist/index.js:15:58)
at <anonymous>
at process._tickDomainCallback (internal/process/next_tick.js:228:7)
```

After digging it, it seems it’s because `executeScript` is not apart of WebdriverIO, but the webdriver _spec_. WebdriverIO has `execute`, which does the same thing. This change seems to make CI happy (because `execute` & `executeScript` seem to be the same thing)

For reference here’s the Webdriver protocol spec: https://w3c.github.io/webdriver/#execute-script
And here’s WebdriverIO’s docs: https://webdriver.io/docs/api/browser/execute.html


## Learning
In WebdriverIO v5 `execute` calls the Webdriver protocols `executeScript`: 

https://github.com/webdriverio/webdriverio/blob/2d7574188346f8269e99ff41c2c32a56b513f491/packages/webdriverio/src/commands/browser/execute.js#L56

But in WebdriverIO v4, it does not: https://github.com/webdriverio/webdriverio/blob/v4.14.1/lib/protocol/execute.js#L64

So this change will open v4 compatibility while maintaining v5 support too. 
