### PR TITLE
fix: Handle different `execute` return values for wdio v4 support

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -23,10 +23,15 @@ export async function percySnapshot(browser: BrowserObject, name: string, option
 
   await browser.execute(fs.readFileSync(agentJsFilename()).toString(), [])
 
-  const domSnapshot = await browser.execute((options: any) => {
+  // WebdriverIO v4 returns an object with the return value from the execute command
+  // WebdriverIO v5 returns whatever is returned from the execute command
+  const browserResult: any = await browser.execute((options: any) => {
     const percyAgentClient = new PercyAgent({ handleAgentCommunication: false })
     return percyAgentClient.snapshot('unused', options)
   }, options)
+
+  const resultIsString = typeof browserResult === "string";
+  const domSnapshot = resultIsString ? browserResult : browserResult.value;
 
   await postDomSnapshot(name, domSnapshot, await browser.getUrl(), options)
 }


### PR DESCRIPTION
## What is this?

Turns out WebdriverIO v4's `execute` command returns an object with the value of what's returned from that function, `sessionId`, and the `status`:

```js
{ sessionId: "2323weinof", value: 'returnValueOfFunction',  _status: 0 }
```

WebdriverIO v5 just returns what is returned from the function. This PR allows us to handle both cases. 

I wish this was easy to test. I confirmed manually this works with our example app using this branch (downgraded to v4): https://github.com/percy/example-webdriverio/tree/rd/wdio4