### PR TITLE
✅ Use Percy CLI testing mode for tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "scripts": {
     "lint": "eslint --ignore-path .gitignore .",
-    "test": "wdio wdio.conf.js",
+    "test": "percy exec --testing -- wdio wdio.conf.js",
     "test:coverage": "nyc yarn test",
     "test:types": "tsd"
   },
@@ -32,7 +32,7 @@
     "webdriverio": "~6 || ~7"
   },
   "devDependencies": {
-    "@percy/core": "^1.1.3",
+    "@percy/cli": "^1.9.1",
     "@wdio/cli": "^7.0.8",
     "@wdio/local-runner": "^7.0.0",
     "@wdio/mocha-framework": "^7.0.7",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -5,23 +5,14 @@ const percySnapshot = require('../index.js');
 describe('percySnapshot', () => {
   let og;
 
-  before(async () => {
-    await helpers.mockSite();
-  });
-
-  after(async () => {
-    await helpers.closeSite();
-  });
-
   beforeEach(async function() {
     og = browser;
     this.timeout(0);
-    await helpers.setup();
-    await browser.url('http://localhost:8000');
+    await helpers.setupTest();
+    await browser.url(helpers.testSnapshotURL);
   });
 
-  afterEach(async () => {
-    await helpers.teardown();
+  afterEach(() => {
     browser = og;
   });
 
@@ -38,54 +29,37 @@ describe('percySnapshot', () => {
   });
 
   it('disables snapshots when the healthcheck fails', async () => {
-    await helpers.testFailure('/percy/healthcheck');
+    await helpers.test('error', '/percy/healthcheck');
 
     await percySnapshot('Snapshot 1');
     await percySnapshot('Snapshot 2');
 
-    await expect(helpers.getRequests()).resolves.toEqual([
-      ['/percy/healthcheck']
-    ]);
-
-    expect(helpers.logger.stderr).toEqual([]);
-    expect(helpers.logger.stdout).toEqual([
-      '[percy] Percy is not running, disabling snapshots'
-    ]);
+    expect(await helpers.get('logs')).toEqual(expect.arrayContaining([
+      'Percy is not running, disabling snapshots'
+    ]));
   });
 
   it('posts snapshots to the local percy server', async () => {
     await percySnapshot('Snapshot 1');
     await percySnapshot('Snapshot 2');
 
-    await expect(helpers.getRequests()).resolves.toEqual([
-      ['/percy/healthcheck'],
-      ['/percy/dom.js'],
-      ['/percy/snapshot', {
-        name: 'Snapshot 1',
-        url: 'http://localhost:8000/',
-        domSnapshot: '<html><head></head><body>Snapshot Me</body></html>',
-        clientInfo: expect.stringMatching(/@percy\/webdriverio\/.+/),
-        environmentInfo: expect.stringMatching(/webdriverio\/.+/)
-      }],
-      ['/percy/snapshot', expect.objectContaining({
-        name: 'Snapshot 2'
-      })]
-    ]);
-
-    expect(helpers.logger.stdout).toEqual([]);
-    expect(helpers.logger.stderr).toEqual([]);
+    expect(await helpers.get('logs')).toEqual(expect.arrayContaining([
+      'Snapshot found: Snapshot 1',
+      'Snapshot found: Snapshot 2',
+      `- url: ${helpers.testSnapshotURL}`,
+      expect.stringMatching(/clientInfo: @percy\/webdriverio\/.+/),
+      expect.stringMatching(/environmentInfo: webdriverio\/.+/)
+    ]));
   });
 
   it('handles snapshot failures', async () => {
-    await helpers.testFailure('/percy/snapshot', 'failure');
+    await helpers.test('error', '/percy/snapshot');
 
     await percySnapshot('Snapshot 1');
 
-    expect(helpers.logger.stdout).toHaveLength(0);
-    expect(helpers.logger.stderr).toEqual([
-      '[percy] Could not take DOM snapshot "Snapshot 1"',
-      '[percy] Error: failure'
-    ]);
+    expect(await helpers.get('logs')).toEqual(expect.arrayContaining([
+      'Could not take DOM snapshot "Snapshot 1"'
+    ]));
   });
 
   it('works in standalone mode', async () => {
@@ -94,18 +68,13 @@ describe('percySnapshot', () => {
     await percySnapshot(og, 'Snapshot 1');
     await percySnapshot(og, 'Snapshot 2');
 
-    await expect(helpers.getRequests()).resolves.toEqual([
-      ['/percy/healthcheck'],
-      ['/percy/dom.js'],
-      ['/percy/snapshot', expect.objectContaining({
-        name: 'Snapshot 1'
-      })],
-      ['/percy/snapshot', expect.objectContaining({
-        name: 'Snapshot 2'
-      })]
-    ]);
-
-    expect(helpers.logger.stderr).toEqual([]);
+    expect(await helpers.get('logs')).toEqual(expect.arrayContaining([
+      'Snapshot found: Snapshot 1',
+      'Snapshot found: Snapshot 2',
+      `- url: ${helpers.testSnapshotURL}`,
+      expect.stringMatching(/clientInfo: @percy\/webdriverio\/.+/),
+      expect.stringMatching(/environmentInfo: webdriverio\/.+/)
+    ]));
   });
 
   it('throws the proper argument error in standalone mode', async () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -286,33 +286,96 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
-"@percy/client@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@percy/client/-/client-1.9.0.tgz#66cadb1e052034d05b3524c2928fda652820e0be"
-  integrity sha512-Rc0S0s7bXbomxILxOQFbE7u8FUUcMa1NQGGB8ioFjn8uh+5Qs19ERmqe6/J60MNUcPuXZCcoqDDbqEyKV0OGZQ==
+"@percy/cli-build@1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@percy/cli-build/-/cli-build-1.9.1.tgz#aa2408929bf116a7742c62ebadb3b1e30844fa07"
+  integrity sha512-BeviHvXOnX74Cntw99hRe0HY2eiqFm9BASkfjSB5AoEdtxLKm0xfYM0WcOIec5XtlztRrQKHA49VVOh2pLWK1Q==
   dependencies:
-    "@percy/env" "1.9.0"
-    "@percy/logger" "1.9.0"
+    "@percy/cli-command" "1.9.1"
 
-"@percy/config@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@percy/config/-/config-1.9.0.tgz#6811c9ef3e67bac9c344a87ea3efe5101d1cc17c"
-  integrity sha512-g0HnUhk6nfTXp9rndBBWw3beXT8Vhfh2iQv8tJjgUY9I0catj2qkAhhSiWHY8qyBLe6ImXB7GYTGeIIyU7s1gw==
+"@percy/cli-command@1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@percy/cli-command/-/cli-command-1.9.1.tgz#bf492875573fc4fc63a9ebf62b33749f298442e6"
+  integrity sha512-4vzOUyorU+0KbqpqXTlSfqRBi+XCPDuPRekNwd0HTsgIQB3KQ8Us5cEhk5x2q8/y0jPHqCb5BK/GJBpS8lwO3Q==
   dependencies:
-    "@percy/logger" "1.9.0"
+    "@percy/config" "1.9.1"
+    "@percy/core" "1.9.1"
+    "@percy/logger" "1.9.1"
+
+"@percy/cli-config@1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@percy/cli-config/-/cli-config-1.9.1.tgz#e095bf66bec66db0bced9ee926c30a211936321a"
+  integrity sha512-R6bimILhdLswXWnIyU+1+X3h6N0xXuwOBcNT8X3GrcTrBFZJpDJ7CNCxj7f6B5Z5uuEFsvdJKN8rRYfVKLRpwg==
+  dependencies:
+    "@percy/cli-command" "1.9.1"
+
+"@percy/cli-exec@1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@percy/cli-exec/-/cli-exec-1.9.1.tgz#31ff86b372dc44ce163c0f218c8758413c84d89e"
+  integrity sha512-upWZhJYBvIbQYPhkh0np+RfMYthnhph1FXwaa/Rj4N+RiU/Qb0rFwDf6fz1Je0m1XNPhXu1R/5FnC30W+SsgAg==
+  dependencies:
+    "@percy/cli-command" "1.9.1"
+    cross-spawn "^7.0.3"
+    which "^2.0.2"
+
+"@percy/cli-snapshot@1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@percy/cli-snapshot/-/cli-snapshot-1.9.1.tgz#b494484b08bbc5927bc7b6a9353c4d59b076be0e"
+  integrity sha512-cI4oXI6vrDPEuQaU4xx6wmMozyzhUooNBRh+flu52CQcog6K9DuJnkUuu+Uf/guMX2tacp30UfAq/IMaH3AenA==
+  dependencies:
+    "@percy/cli-command" "1.9.1"
+    yaml "^2.0.0"
+
+"@percy/cli-upload@1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@percy/cli-upload/-/cli-upload-1.9.1.tgz#f1d97be77cd36574b5a57129be1d3dc1c81bb374"
+  integrity sha512-g72PepLUU0XgZiYSGcSn8nUxTbEW7NYGgh+uo/J3rnIp5OyH5olpIz/+r3+OXezAAwgyLQTSv+/pYY4ClkvQaQ==
+  dependencies:
+    "@percy/cli-command" "1.9.1"
+    fast-glob "^3.2.11"
+    image-size "^1.0.0"
+
+"@percy/cli@^1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@percy/cli/-/cli-1.9.1.tgz#0df5b6af5dd848ed1c2a57db4f6e2b547583fe3c"
+  integrity sha512-B62SYu2vHGcR1lkQzP2RHHJRjuEBoWwgeccwBf3mYSzwl4fEB6n1feBRKDx7UNCazRnAzXKrL+g4X7FIesHqnA==
+  dependencies:
+    "@percy/cli-build" "1.9.1"
+    "@percy/cli-command" "1.9.1"
+    "@percy/cli-config" "1.9.1"
+    "@percy/cli-exec" "1.9.1"
+    "@percy/cli-snapshot" "1.9.1"
+    "@percy/cli-upload" "1.9.1"
+    "@percy/client" "1.9.1"
+    "@percy/logger" "1.9.1"
+
+"@percy/client@1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@percy/client/-/client-1.9.1.tgz#b6d7278436942bf241154cd79a123e23c4cdbcba"
+  integrity sha512-8A2WBoXV+zFT/+P2j8fflPOhv7dX0LNrk6bivgB6E1d6o9xcxEO94KNEIlU4hWkFC2vi+u5fpQXi+OWYQle2wQ==
+  dependencies:
+    "@percy/env" "1.9.1"
+    "@percy/logger" "1.9.1"
+
+"@percy/config@1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@percy/config/-/config-1.9.1.tgz#382d0ff8d7b94da7cbe5ad823c5553b1c9af11a7"
+  integrity sha512-LY8SBM7ngoLOItr6HOqu0dludsw6G/8dk7U3aMivzUYMZuO05maD7XlTTqfYr8HKUvxG7F6ZXQrRSG0SvwOFVg==
+  dependencies:
+    "@percy/logger" "1.9.1"
     ajv "^8.6.2"
     cosmiconfig "^7.0.0"
     yaml "^2.0.0"
 
-"@percy/core@^1.1.3":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@percy/core/-/core-1.9.0.tgz#665e4dcc1a6516b0a9e9cf2569986c17d2297f3e"
-  integrity sha512-9BdqyetwhNUV2AGr65PZfBo5oms6eKzc0hi1yb43Dlb7EY0RRBFq01EXT5J71wEgNqsTk0B7IZ+fBvJwjcbOfw==
+"@percy/core@1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@percy/core/-/core-1.9.1.tgz#ba5a22073cfbf15c20b1964986a8f50b5ee5d024"
+  integrity sha512-LLqRoqd2AmbcV4CXQBceeaoZlQGSUN5qyfsNRYQ/7c8AmgTbccy5C1N8bpqaeiyqTpJWduXFGg1TI9awgi1UWQ==
   dependencies:
-    "@percy/client" "1.9.0"
-    "@percy/config" "1.9.0"
-    "@percy/dom" "1.9.0"
-    "@percy/logger" "1.9.0"
+    "@percy/client" "1.9.1"
+    "@percy/config" "1.9.1"
+    "@percy/dom" "1.9.1"
+    "@percy/logger" "1.9.1"
     content-disposition "^0.5.4"
     cross-spawn "^7.0.3"
     extract-zip "^2.0.1"
@@ -323,25 +386,25 @@
     rimraf "^3.0.2"
     ws "^8.0.0"
 
-"@percy/dom@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@percy/dom/-/dom-1.9.0.tgz#4d52fb401111006ef49bd3b8cdc3fe9700ebcb55"
-  integrity sha512-Js0JCow9d4g7wqTqGgzwIMKG8apV/6BUJ7vM57K1t2y+MLiPKDiu4VC+6WIxIDs2wAUIN6j5byQKNv/G337qzA==
+"@percy/dom@1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@percy/dom/-/dom-1.9.1.tgz#0a034be46260d440884e6a3c5d4bda04eeff49af"
+  integrity sha512-/3q0SkimuCHANbQlnT1pDPQNb01YHtEEYNvkLv4SHFGkbOyGkZb2QEXbPryjZ0ApgLi3nm7TkKR6kNXugprhXw==
 
-"@percy/env@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@percy/env/-/env-1.9.0.tgz#cd599c604a0e764b5c1114cfab839aed766d1dd4"
-  integrity sha512-xkg0oSX7FHXA9T9aLUhvl9YsG1arYFdt8BNTcrDW//kOt/oJX/9hsBXlVxpfhUcK21S7TPvv3UEVVkOW/ZCMlg==
+"@percy/env@1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@percy/env/-/env-1.9.1.tgz#568bd6b7048fe1fd2cf00de24a423bd807d6fe23"
+  integrity sha512-8zkZrNDBuPFUA6gSi7rYeK+TMuXTgH6bQCQYPlQJuIrSXA4CbLWaL8S3qX69hk91F9DB4glhIgR9N4RWO+R5EQ==
 
-"@percy/logger@1.9.0":
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/@percy/logger/-/logger-1.9.0.tgz#945239dbaaf543e460a81fe5ba4a91ab8c6bb92e"
-  integrity sha512-lnRE8PkvAjSriztJqUkVT+qNhGMjNK+UTL4aUYA/WVAYDLeQmhCRREHHc301X8sFyPIOyQ1KA1WzCEfFuHisaA==
+"@percy/logger@1.9.1":
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@percy/logger/-/logger-1.9.1.tgz#d5a4f30ca60d56eb2b1700fb56fd8e4e55dfbbfa"
+  integrity sha512-WOtU8eX/fsgz49Hh6N8hSpy95WJV209G9yGFVaZXWIbKJ90FWrONksX/Kz8FxQ0q/7oIW36zXy0ibr2qRy095g==
 
 "@percy/sdk-utils@^1.0.0":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@percy/sdk-utils/-/sdk-utils-1.8.0.tgz#8db2aefbb211747f8f622db6daf25b781464a308"
-  integrity sha512-ehyYs7L4MDmqjBAfTHA8wDGrsDHiPrJ5SwMA9g9tT06VUey1JJtjSK30VidoouZQm+Sus9r5lW/K73CQZc3lSg==
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/@percy/sdk-utils/-/sdk-utils-1.9.1.tgz#daa5d2cb9a2dfb306c094c3b6e1ae3891846f5e4"
+  integrity sha512-/9k1XDYj3xl9xI/cQM1uItIcC8HWpm12sYVAZRMKdddCPc3SAQN93sgVZXF3L4uGgaNiTD1+AtkzuUVSccUpPQ==
 
 "@sindresorhus/is@^4.0.0":
   version "4.0.0"
@@ -2416,6 +2479,13 @@ ignore@^5.1.1, ignore@^5.1.4:
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.1.4.tgz#84b7b3dbe64552b6ef0eca99f6743dbec6d97adf"
   integrity sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==
 
+image-size@^1.0.0:
+  version "1.0.2"
+  resolved "https://registry.yarnpkg.com/image-size/-/image-size-1.0.2.tgz#d778b6d0ab75b2737c1556dd631652eb963bc486"
+  integrity sha512-xfOoWjceHntRb3qFCrh5ZFORYH8XCdYpASltMhZ/Q0KZiOwjdE/Yl2QCiWdwD+lygV5bMCvauzgu5PxBX/Yerg==
+  dependencies:
+    queue "6.0.2"
+
 import-fresh@^3.0.0, import-fresh@^3.2.1:
   version "3.2.2"
   resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.2.2.tgz#fc129c160c5d68235507f4331a6baad186bdbc3e"
@@ -3752,6 +3822,13 @@ query-selector-shadow-dom@^1.0.0:
   resolved "https://registry.yarnpkg.com/query-selector-shadow-dom/-/query-selector-shadow-dom-1.0.0.tgz#8fa7459a4620f094457640e74e953a9dbe61a38e"
   integrity sha512-bK0/0cCI+R8ZmOF1QjT7HupDUYCxbf/9TJgAmSXQxZpftXmTAeil9DRoCnTDkWbvOyZzhcMBwKpptWcdkGFIMg==
 
+queue@6.0.2:
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/queue/-/queue-6.0.2.tgz#b91525283e2315c7553d2efa18d83e76432fed65"
+  integrity sha512-iHZWu+q3IdFZFX36ro/lKBkSvfkztY5Y7HMiPlOUjhupPcG2JMfst2KKEpu5XndviX/3UhFbRngUPNKtgvtZiA==
+  dependencies:
+    inherits "~2.0.3"
+
 quick-lru@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
@@ -4644,7 +4721,7 @@ which@^1.2.9:
   dependencies:
     isexe "^2.0.0"
 
-which@^2.0.1:
+which@^2.0.1, which@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/which/-/which-2.0.2.tgz#7c6a8dd0a636a0327e10b59c9286eee93f3f51b1"
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==


### PR DESCRIPTION
## What is this?

This PR updates tests to utilize CLI's new testing mode and updated `@percy/sdk-utils` test helpers.