### PR TITLE
fix: wdio v8 uses relative path

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const utils = require('@percy/sdk-utils');
 
 // Collect client and environment information
 const sdkPkg = require('./package.json');
-const webdriverioPkg = require('webdriverio/package.json');
+const webdriverioPkg = require('../webdriverio/package.json');
 const CLIENT_INFO = `${sdkPkg.name}/${sdkPkg.version}`;
 const ENV_INFO = `${webdriverioPkg.name}/${webdriverioPkg.version}`;
 

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const utils = require('@percy/sdk-utils');
 
 // Collect client and environment information
 const sdkPkg = require('./package.json');
-const webdriverioPkg = require('../webdriverio/package.json');
+const webdriverioPkg = require('../../webdriverio/package.json');
 const CLIENT_INFO = `${sdkPkg.name}/${sdkPkg.version}`;
 const ENV_INFO = `${webdriverioPkg.name}/${webdriverioPkg.version}`;
 


### PR DESCRIPTION
Attempt to fix this error when running with wdio v8:
```
Error: Error: Package subpath './package.json' is not defined by "exports" in /Users/ ... /node_mo
dules/webdriverio/package.json
```
Offending line:
```
Users/ ... /node_modules/@percy/webdriverio/index.js:5:24
```
see v8 release notes section here https://webdriver.io/blog/2022/12/01/webdriverio-v8-released#miscellaneous