### PR TITLE
🏗️ Make error message when installing wdio version `<8.6.6` 

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@percy/sdk-utils": "^1.0.0"
   },
   "peerDependencies": {
-    "webdriverio": "~6 || ~7 || >=8.7"
+    "webdriverio": "~6 || ~7 || ^8.6.6"
   },
   "devDependencies": {
     "@percy/cli": "^1.10.4",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "@percy/sdk-utils": "^1.0.0"
   },
   "peerDependencies": {
-    "webdriverio": "~6 || ~7 || ~8"
+    "webdriverio": "~6 || ~7 || >=8.7"
   },
   "devDependencies": {
     "@percy/cli": "^1.10.4",


### PR DESCRIPTION
In https://github.com/percy/percy-webdriverio/pull/1053 we'd reverted the patch we performed in our SDK till wdio supports exporting `package.json` 

`8.6.6` version of wdio is when the patch was released, in this PR we'll be giving better errors during installation that this version is only compatible with wdio v8.6.6 or higher