### PR TITLE
Update percy cli to 1.30.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,14 +26,14 @@
     "test:types": "tsd"
   },
   "dependencies": {
-    "@percy/sdk-utils": "^1.30.1"
+    "@percy/sdk-utils": "^1.30.3"
   },
   "peerDependencies": {
     "webdriverio": "~6 || ~7 || ~8 || ~ 9"
   },
   "devDependencies": {
     "@eslint/js": "^9.13.0",
-    "@percy/cli": "^1.30.1",
+    "@percy/cli": "^1.30.3",
     "@wdio/cli": "^9.2.1",
     "@wdio/jasmine-framework": "^9.2.1",
     "@wdio/local-runner": "^9.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -649,108 +649,108 @@
     "@nodelib/fs.scandir" "2.1.3"
     fastq "^1.6.0"
 
-"@percy/cli-app@1.30.1":
-  version "1.30.1"
-  resolved "https://registry.yarnpkg.com/@percy/cli-app/-/cli-app-1.30.1.tgz#3238f43fb6bfa9e358567024b13603556b0d2bca"
-  integrity sha512-/ZLGjAFeQKHeaQI5xQ9w6lLljEKWXB/+QuIHl3kGK+NL1+cZtRBk6oDbWj+QRKxg/tr+3zvwjioNIdkDaXgXUQ==
+"@percy/cli-app@1.30.3":
+  version "1.30.3"
+  resolved "https://registry.yarnpkg.com/@percy/cli-app/-/cli-app-1.30.3.tgz#8b3f7b87628f7ad80b236704578b890535ce0cba"
+  integrity sha512-aZE7jGbBFXGJkLj3yf1VfF2mjUAPOB+pZLmnHSpDLenNYcof6RhbyRdkdsSuSz9HQEE6Q3n4Ae20nCEss6LvOQ==
   dependencies:
-    "@percy/cli-command" "1.30.1"
-    "@percy/cli-exec" "1.30.1"
+    "@percy/cli-command" "1.30.3"
+    "@percy/cli-exec" "1.30.3"
 
-"@percy/cli-build@1.30.1":
-  version "1.30.1"
-  resolved "https://registry.yarnpkg.com/@percy/cli-build/-/cli-build-1.30.1.tgz#b69f62b0b1008379b31a5c4eb64b7d9a98a79703"
-  integrity sha512-jr9URjHjYKBchUy7I0eh2agGzpN5Ct+A/Q+jlUbkR5N7AyXW3FbkbA6ZiPYXuG+i2Sjm1wuxMGPKMSIKTVZ3GQ==
+"@percy/cli-build@1.30.3":
+  version "1.30.3"
+  resolved "https://registry.yarnpkg.com/@percy/cli-build/-/cli-build-1.30.3.tgz#35201ae47b30da25bac92ec6e6eee7d5267e29e0"
+  integrity sha512-XLE5PjaQQ+FbBBq1OD8AULqr8lMsl6PO9cvzCIAsnht/4BlimzPpZ3IkTf7XHylpqsvXHJ3T7MoZvci9p/dyPg==
   dependencies:
-    "@percy/cli-command" "1.30.1"
+    "@percy/cli-command" "1.30.3"
 
-"@percy/cli-command@1.30.1":
-  version "1.30.1"
-  resolved "https://registry.yarnpkg.com/@percy/cli-command/-/cli-command-1.30.1.tgz#e15de45248cbae74887f4b00334e7ece91569451"
-  integrity sha512-a8qoZu4IaPp6cKse5ovruI6oeuXJQR2D2aJGwDpnaBbryX4ArSX+x0LoI59SfdEisUxf5JPjiSPmixTmWUxqxA==
+"@percy/cli-command@1.30.3":
+  version "1.30.3"
+  resolved "https://registry.yarnpkg.com/@percy/cli-command/-/cli-command-1.30.3.tgz#aabd0e62b781ea76c247cab9b302bb49a0222624"
+  integrity sha512-HSvxXZZt3Igum/nyxV/utDu/MQNn6zFHiHLgYxElkCr/cyBVzgCnFbWbCeSNhPAum6fVpgOH4l0NLku+SX35xw==
   dependencies:
-    "@percy/config" "1.30.1"
-    "@percy/core" "1.30.1"
-    "@percy/logger" "1.30.1"
+    "@percy/config" "1.30.3"
+    "@percy/core" "1.30.3"
+    "@percy/logger" "1.30.3"
 
-"@percy/cli-config@1.30.1":
-  version "1.30.1"
-  resolved "https://registry.yarnpkg.com/@percy/cli-config/-/cli-config-1.30.1.tgz#3358b4a4190b5b2c7152702ea65e6a6b1d8d5389"
-  integrity sha512-Rgefm7jyYNdh86eEWj+TKeXhKC1+thlSzFQEraTaanhacBaVHDwEtd5x1hmRMQZPiI759cwVh+dFus3n8DwsaQ==
+"@percy/cli-config@1.30.3":
+  version "1.30.3"
+  resolved "https://registry.yarnpkg.com/@percy/cli-config/-/cli-config-1.30.3.tgz#fe0717e8b664d85c7567423af0d651d3688ed102"
+  integrity sha512-D2W+GJFejnXXfm5vyKq5CoLuHP5c2foheJ12dEu9d/IKePhblPLWd53bKZvHzD1LC9nk6DocKa4AAVQ+4JJV0w==
   dependencies:
-    "@percy/cli-command" "1.30.1"
+    "@percy/cli-command" "1.30.3"
 
-"@percy/cli-exec@1.30.1":
-  version "1.30.1"
-  resolved "https://registry.yarnpkg.com/@percy/cli-exec/-/cli-exec-1.30.1.tgz#e660038140fd31b8dce03640b438396d8b44cb19"
-  integrity sha512-XsXzfXUIrpKo/3CmgffgVurLlVFlThCO+Kc5IV83ggJhdFAVoJc9cSLOgZyrTBsKEprHmWi5Wn4RLMXhxlaGVg==
+"@percy/cli-exec@1.30.3":
+  version "1.30.3"
+  resolved "https://registry.yarnpkg.com/@percy/cli-exec/-/cli-exec-1.30.3.tgz#0d6f376a52042ad184903b4ac5a96ebfb5422773"
+  integrity sha512-Wp3dIbqF3M9f+CkiZcOEZPkCGGKtWytbs4eJ0PcxGFQG6gH9Dv/BeTncCy23zNjvwlgzAxlMvxuoHcVf7RkkpA==
   dependencies:
-    "@percy/cli-command" "1.30.1"
-    "@percy/logger" "1.30.1"
+    "@percy/cli-command" "1.30.3"
+    "@percy/logger" "1.30.3"
     cross-spawn "^7.0.3"
     which "^2.0.2"
 
-"@percy/cli-snapshot@1.30.1":
-  version "1.30.1"
-  resolved "https://registry.yarnpkg.com/@percy/cli-snapshot/-/cli-snapshot-1.30.1.tgz#1684d35927b3de73c64374d676fd12c058ad0f78"
-  integrity sha512-86ahSoh3PgbM8ZAL38PVz4X6NMTKsyHTfnGf8T0KH9/MLLp2uokJPJTIpXkPq4OeqzNEq2eOHzaRuXf5wOeHtw==
+"@percy/cli-snapshot@1.30.3":
+  version "1.30.3"
+  resolved "https://registry.yarnpkg.com/@percy/cli-snapshot/-/cli-snapshot-1.30.3.tgz#3f206579db08dd8d0abef940222f514b3f14b9aa"
+  integrity sha512-y2GySH5YQZUbF9yoCPEzDclnJBMDBuUSKnOkauIsHn7fBpi61Dl1BaWv5OJbllGzkJ8yZnMjaJic/ydSBXl3FQ==
   dependencies:
-    "@percy/cli-command" "1.30.1"
+    "@percy/cli-command" "1.30.3"
     yaml "^2.0.0"
 
-"@percy/cli-upload@1.30.1":
-  version "1.30.1"
-  resolved "https://registry.yarnpkg.com/@percy/cli-upload/-/cli-upload-1.30.1.tgz#d066c963b63a5fc21031531575f0519f498b422b"
-  integrity sha512-wRR4yLI5tKGXz5Y6ZaufLRo2yKVGZVA4zZsYLTbQgmgPxnAYCc5/eu1C2cxfvgeCxNZqwmS6giqxMzfa5z9nKg==
+"@percy/cli-upload@1.30.3":
+  version "1.30.3"
+  resolved "https://registry.yarnpkg.com/@percy/cli-upload/-/cli-upload-1.30.3.tgz#1f2b05fe84866ec54d13b817a1b337b18df5b2fd"
+  integrity sha512-pQEueqDhBqWAS9z/ZvBrL7RX8Fxev5MY11vlbrrTZI0qLaN7J6Vkqz6j33JcZAAYOP6hHfsBg5iy2qGYDbgk+Q==
   dependencies:
-    "@percy/cli-command" "1.30.1"
+    "@percy/cli-command" "1.30.3"
     fast-glob "^3.2.11"
     image-size "^1.0.0"
 
-"@percy/cli@^1.30.1":
-  version "1.30.1"
-  resolved "https://registry.yarnpkg.com/@percy/cli/-/cli-1.30.1.tgz#e14234803e9d64dffb71f4fb5b4565a3b2d49556"
-  integrity sha512-9mLD6q5nT106+Qxkkw28GVxcL2vgqG9mO6Tp55MeEjySSh+EBpadsCUh93oDN64ZcRUObAE56B+sy4H8PkBLGQ==
+"@percy/cli@^1.30.3":
+  version "1.30.3"
+  resolved "https://registry.yarnpkg.com/@percy/cli/-/cli-1.30.3.tgz#bb9b3a19595b00ab48c7c1a0bf45fdd3321a3481"
+  integrity sha512-oKuqacqtIJkA70lMB7Q5UeWGxGEMTGqWcf54vHsKrTgBAoK5sI0IOMhXwtJNYZrvZdZVSrY39VHKU2cQBcxhaA==
   dependencies:
-    "@percy/cli-app" "1.30.1"
-    "@percy/cli-build" "1.30.1"
-    "@percy/cli-command" "1.30.1"
-    "@percy/cli-config" "1.30.1"
-    "@percy/cli-exec" "1.30.1"
-    "@percy/cli-snapshot" "1.30.1"
-    "@percy/cli-upload" "1.30.1"
-    "@percy/client" "1.30.1"
-    "@percy/logger" "1.30.1"
+    "@percy/cli-app" "1.30.3"
+    "@percy/cli-build" "1.30.3"
+    "@percy/cli-command" "1.30.3"
+    "@percy/cli-config" "1.30.3"
+    "@percy/cli-exec" "1.30.3"
+    "@percy/cli-snapshot" "1.30.3"
+    "@percy/cli-upload" "1.30.3"
+    "@percy/client" "1.30.3"
+    "@percy/logger" "1.30.3"
 
-"@percy/client@1.30.1":
-  version "1.30.1"
-  resolved "https://registry.yarnpkg.com/@percy/client/-/client-1.30.1.tgz#28461039f1891a6724ce624442c14ca3c80217c9"
-  integrity sha512-vaue3/dOykOWZ9ER/vecb9mkcuTe72wgCrYbzIcKNtSUc5AQEGiV5c8rGZav868i5YCtGejexWZ7PKDO05asag==
+"@percy/client@1.30.3":
+  version "1.30.3"
+  resolved "https://registry.yarnpkg.com/@percy/client/-/client-1.30.3.tgz#34493a4358f5d973567256263e4801be9dbdb4fb"
+  integrity sha512-2gepzFyAGiyFjQ33RTkO7RMfgnnCB5Fo7Cc6lU7WbJB4CyLF9+khl0Cgd48d1flLOZDhFdItGuLiwcnpkvDNcw==
   dependencies:
-    "@percy/env" "1.30.1"
-    "@percy/logger" "1.30.1"
+    "@percy/env" "1.30.3"
+    "@percy/logger" "1.30.3"
     pako "^2.1.0"
 
-"@percy/config@1.30.1":
-  version "1.30.1"
-  resolved "https://registry.yarnpkg.com/@percy/config/-/config-1.30.1.tgz#553beb1b4aa46ad57d93904537c605144d49b1d6"
-  integrity sha512-wvI2QIf7/oLPsnrXGHFCLRdDY5BRFE3Smil8IY2ijtGUFWXRPsmRx2tjSdbZ/kpctkeyZappNHPzSiwi1MjJlA==
+"@percy/config@1.30.3":
+  version "1.30.3"
+  resolved "https://registry.yarnpkg.com/@percy/config/-/config-1.30.3.tgz#6cfdf6695bffb84c0244a8cd681ca56440ed0f15"
+  integrity sha512-i+k6H1PsKma0b61347sIW9bEY9/qe1xx/yEIc+bE3oEydjfEDp4IDt9ZBhkeRPYpko67QQ9y9kzGT2v8PYkuxw==
   dependencies:
-    "@percy/logger" "1.30.1"
+    "@percy/logger" "1.30.3"
     ajv "^8.6.2"
     cosmiconfig "^8.0.0"
     yaml "^2.0.0"
 
-"@percy/core@1.30.1":
-  version "1.30.1"
-  resolved "https://registry.yarnpkg.com/@percy/core/-/core-1.30.1.tgz#8dbfdda52fbfea3e3105cc1458d3525b04f2f980"
-  integrity sha512-XQNPFO8ZmKWMMkWaa+IWN6Kzh7CXCwosLWK7OsEldK7N/CVNGmU8mkCwpqYlDXEeiahGfUxqCr4yHZS26OveyQ==
+"@percy/core@1.30.3":
+  version "1.30.3"
+  resolved "https://registry.yarnpkg.com/@percy/core/-/core-1.30.3.tgz#5a0cc594e412d615b85d2c0c9fdc451b6870c734"
+  integrity sha512-ty9Hj1Dr0f6FrHdJIU0e7jCnSfDW/iSF6B6X4jC7ovXw9tbEK/0vt/Q7VZaQiDjmo3tU7gl5DAzsqf8gGVgemg==
   dependencies:
-    "@percy/client" "1.30.1"
-    "@percy/config" "1.30.1"
-    "@percy/dom" "1.30.1"
-    "@percy/logger" "1.30.1"
-    "@percy/webdriver-utils" "1.30.1"
+    "@percy/client" "1.30.3"
+    "@percy/config" "1.30.3"
+    "@percy/dom" "1.30.3"
+    "@percy/logger" "1.30.3"
+    "@percy/webdriver-utils" "1.30.3"
     content-disposition "^0.5.4"
     cross-spawn "^7.0.3"
     extract-zip "^2.0.1"
@@ -763,35 +763,35 @@
     ws "^8.17.1"
     yaml "^2.4.1"
 
-"@percy/dom@1.30.1":
-  version "1.30.1"
-  resolved "https://registry.yarnpkg.com/@percy/dom/-/dom-1.30.1.tgz#d736494d8d7b7f1a3cef747b1f37bd822476327b"
-  integrity sha512-dYHVGETIXzwqchShfzOkCrGCqjw/KLsubUZR3PYWd6UtTWZ9kFWr9I6MzizPE4XfhJs5rQ0e0Keb29FrGTey5Q==
+"@percy/dom@1.30.3":
+  version "1.30.3"
+  resolved "https://registry.yarnpkg.com/@percy/dom/-/dom-1.30.3.tgz#52ba9104dcc2a0fbaa6f9a0dd778b5b6badda15e"
+  integrity sha512-bqHx66hwpzNihlTe2y9nu8FxHKfBmzKqcrxPa8ItMx8dFglWqEzjA9phrgSeFRs5yjrMUO6MuPtuj5reHrmoqQ==
 
-"@percy/env@1.30.1":
-  version "1.30.1"
-  resolved "https://registry.yarnpkg.com/@percy/env/-/env-1.30.1.tgz#aacf1bb12a5261d2bb046a507b8fd722614b80fa"
-  integrity sha512-ib9Ty/zo/+kfQSRC7RyzxnrS5zzsaoWJLgvTUDwi4iv/UIvx6vrEp7YPE0FQu1VGoRoL7zxRKalTh06/kBAsXg==
+"@percy/env@1.30.3":
+  version "1.30.3"
+  resolved "https://registry.yarnpkg.com/@percy/env/-/env-1.30.3.tgz#fb6f2473905685b0709a43c3c6862a03f72f2dc0"
+  integrity sha512-42Cx2Z+KJtP+8HOR5rCyQGWT3Swdcz54pXJtBWrmockc/5zLXCqfqG8LN/JHWukNiH2kSiwn1BArWWRbGtqMxw==
   dependencies:
-    "@percy/logger" "1.30.1"
+    "@percy/logger" "1.30.3"
 
-"@percy/logger@1.30.1":
-  version "1.30.1"
-  resolved "https://registry.yarnpkg.com/@percy/logger/-/logger-1.30.1.tgz#d94159ffa48e77cf78e6e6d141054cdf3a21e2dd"
-  integrity sha512-FaVW4YGmgPaW0OviMFUn7m7ski2uZQAeUJ/hg+IXFIN+zSreX2ORcsp+Fep2p+h5UjcZX5wFuf/8O3nth5YAfQ==
+"@percy/logger@1.30.3":
+  version "1.30.3"
+  resolved "https://registry.yarnpkg.com/@percy/logger/-/logger-1.30.3.tgz#1c1aeccc91ef35f1571761891239d0ccc7ab0b30"
+  integrity sha512-AR3ygLmaGz0fpo1RoMt99jDpM8SOlSq/4sGFXSLfbbE4QCMGx4FsfuPRFdG2RpXKQnQN9Wjyi2F4woRAxiJNvg==
 
-"@percy/sdk-utils@1.30.1", "@percy/sdk-utils@^1.30.1":
-  version "1.30.1"
-  resolved "https://registry.yarnpkg.com/@percy/sdk-utils/-/sdk-utils-1.30.1.tgz#005d37efb9736ba59d4a893156b46deb0bb29347"
-  integrity sha512-xdeaHEdQvytFEbNBYCFdu1ToD6T/BT6YtZYwfNKAYXwQqVbm4wr/3LVH+GUcxYZsBCxmeSyCrF4buspUhxTNJQ==
+"@percy/sdk-utils@1.30.3", "@percy/sdk-utils@^1.30.3":
+  version "1.30.3"
+  resolved "https://registry.yarnpkg.com/@percy/sdk-utils/-/sdk-utils-1.30.3.tgz#7d0b05c4be73d1458154625b87e6d3f612defba5"
+  integrity sha512-mMWeWMKtAaJdx+Wcpi5EEQZfWDFV0aOzT6+tNFL/ze7wskM4NF9RXIt0W86wyOSs25XB+kgY9+TuTc/yrR7Jew==
 
-"@percy/webdriver-utils@1.30.1":
-  version "1.30.1"
-  resolved "https://registry.yarnpkg.com/@percy/webdriver-utils/-/webdriver-utils-1.30.1.tgz#649b93b4ee432b909f5d91d3123a1358385de2ce"
-  integrity sha512-mXY40mUBLsdwFMKsZpg87K457a76Qi0Dq8+nZ0rLqYj5STZs3RQWbgi9qMI3ELoB3BqLzePqR9pL8J9WjvRXDg==
+"@percy/webdriver-utils@1.30.3":
+  version "1.30.3"
+  resolved "https://registry.yarnpkg.com/@percy/webdriver-utils/-/webdriver-utils-1.30.3.tgz#00c265d5a2615a7aaedc53ca8ffc25be76674203"
+  integrity sha512-v43jZ0+zeR/eo2fbjMfOcTO0qjgDndrB8cKgwLVd+jJZpGj08nQQJOZYZ87Wrd0s4mDv8PFi5h6Dyt+x8KfjRw==
   dependencies:
-    "@percy/config" "1.30.1"
-    "@percy/sdk-utils" "1.30.1"
+    "@percy/config" "1.30.3"
+    "@percy/sdk-utils" "1.30.3"
 
 "@pkgjs/parseargs@^0.11.0":
   version "0.11.0"
@@ -5394,7 +5394,7 @@ streamx@^2.15.0, streamx@^2.20.0:
   optionalDependencies:
     bare-events "^2.2.0"
 
-"string-width-cjs@npm:string-width@^4.2.0":
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -5420,15 +5420,6 @@ string-width@^4.2.0:
     emoji-regex "^8.0.0"
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
-
-string-width@^4.2.3:
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
 
 string-width@^5.0.1, string-width@^5.1.2:
   version "5.1.2"
@@ -5481,7 +5472,7 @@ string_decoder@~1.1.1:
   dependencies:
     safe-buffer "~5.1.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -5501,13 +5492,6 @@ strip-ansi@^6.0.0:
   integrity sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
   dependencies:
     ansi-regex "^5.0.0"
-
-strip-ansi@^6.0.1:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
 
 strip-ansi@^7.0.1, strip-ansi@^7.1.0:
   version "7.1.0"
@@ -6096,7 +6080,7 @@ word-wrap@^1.2.5:
   resolved "https://registry.yarnpkg.com/word-wrap/-/word-wrap-1.2.5.tgz#d2c45c6dd4fbce621a66f136cbe328afd0410b34"
   integrity sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==
 
-"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0":
+"wrap-ansi-cjs@npm:wrap-ansi@^7.0.0", wrap-ansi@^7.0.0:
   version "7.0.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
   integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
@@ -6109,15 +6093,6 @@ wrap-ansi@^6.2.0:
   version "6.2.0"
   resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-6.2.0.tgz#e9393ba07102e6c91a3b221478f0257cd2856e53"
   integrity sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
-  dependencies:
-    ansi-styles "^4.0.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-
-wrap-ansi@^7.0.0:
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/wrap-ansi/-/wrap-ansi-7.0.0.tgz#67e145cff510a6a6984bdf1152911d69d2eb9e43"
-  integrity sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
   dependencies:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"


### PR DESCRIPTION
- Update percy cli to 1.30.3
- This adds new options in typescript SnapshotOptions