### PR TITLE
feat: PER-7348 add waitForReady() call before serialize()

### DIFF
--- a/index.js
+++ b/index.js
@@ -45,23 +45,18 @@ module.exports = function percySnapshot(b, name, options) {
       // Inject the DOM serialization script
       await b.execute(await utils.fetchPercyDOM());
 
-      // Readiness gate. `waitForReadyScript({ callback: true })` is
-      // the shared callback-mode helper from @percy/sdk-utils — uses
-      // `arguments[arguments.length - 1]` for the executeAsync done callback,
-      // which is robust across WebdriverIO Promise-handling variations.
       // Readiness gate. All orchestration lives in @percy/sdk-utils
-      // 1.31.15+: disabled-check + shallow-merge config + callback-mode script
-      // generation + try/catch. typeof guard for backward compat — degrades
-      // to no-op on older sdk-utils versions.
-      let readinessDiagnostics;
-      /* istanbul ignore else: covered once sdk-utils 1.31.15 is published */
-      if (typeof utils.runReadinessGate === 'function') {
-        readinessDiagnostics = await utils.runReadinessGate(
-          (script) => b.executeAsync(script),
-          options,
-          { callback: true, log }
-        );
-      }
+      // (disabled-check + shallow-merge config + callback-mode script
+      // generation + try/catch). callback: true makes waitForReadyScript
+      // use arguments[arguments.length - 1] for the executeAsync done
+      // callback, which is robust across WebdriverIO Promise-handling
+      // variations. The package.json floor pins runReadinessGate to be
+      // present.
+      const readinessDiagnostics = await utils.runReadinessGate(
+        (script) => b.executeAsync(script),
+        options,
+        { callback: true, log }
+      );
 
       // Serialize and capture the DOM
       /* istanbul ignore next: no instrumenting injected code */

--- a/index.js
+++ b/index.js
@@ -45,11 +45,11 @@ module.exports = function percySnapshot(b, name, options) {
       // Inject the DOM serialization script
       await b.execute(await utils.fetchPercyDOM());
 
-      // Readiness gate (PER-7348). `waitForReadyScript({ callback: true })` is
+      // Readiness gate. `waitForReadyScript({ callback: true })` is
       // the shared callback-mode helper from @percy/sdk-utils — uses
       // `arguments[arguments.length - 1]` for the executeAsync done callback,
       // which is robust across WebdriverIO Promise-handling variations.
-      // Readiness gate (PER-7348). All orchestration lives in @percy/sdk-utils
+      // Readiness gate. All orchestration lives in @percy/sdk-utils
       // 1.31.15+: disabled-check + shallow-merge config + callback-mode script
       // generation + try/catch. typeof guard for backward compat — degrades
       // to no-op on older sdk-utils versions.

--- a/index.js
+++ b/index.js
@@ -45,12 +45,37 @@ module.exports = function percySnapshot(b, name, options) {
       // Inject the DOM serialization script
       await b.execute(await utils.fetchPercyDOM());
 
+      // Readiness gate — runs before serialize when CLI supports it (PER-7348).
+      // Uses executeAsync with a callback signal (robust across WebdriverIO
+      // Promise-handling variations). In-browser typeof guard makes this a
+      // no-op on older CLIs that lack PercyDOM.waitForReady.
+      let readinessDiagnostics;
+      const readinessConfig = options?.readiness || utils.percy?.config?.snapshot?.readiness || {};
+      if (readinessConfig.preset !== 'disabled') {
+        try {
+          readinessDiagnostics = await b.executeAsync(function(cfg, done) {
+            try {
+              if (typeof PercyDOM !== 'undefined' && typeof PercyDOM.waitForReady === 'function') {
+                PercyDOM.waitForReady(cfg).then(function(r) { done(r); }).catch(function() { done(); });
+              } else { done(); }
+            } catch (e) { done(); }
+          }, readinessConfig);
+        } catch (err) {
+          log.debug(`waitForReady failed, proceeding to serialize: ${err?.message || err}`);
+        }
+      }
+
       // Serialize and capture the DOM
       /* istanbul ignore next: no instrumenting injected code */
       let { domSnapshot, url } = await b.execute(async (options) => ({
         domSnapshot: await PercyDOM.serialize(options),
         url: document.URL
       }), options);
+
+      // Attach readiness diagnostics so the CLI can log timing and pass/fail
+      if (readinessDiagnostics && domSnapshot && typeof domSnapshot === 'object') {
+        domSnapshot.readiness_diagnostics = readinessDiagnostics;
+      }
 
       // Post the DOM to the snapshot endpoint with snapshot options and other info
       const response = await module.exports.request({

--- a/index.js
+++ b/index.js
@@ -49,11 +49,20 @@ module.exports = function percySnapshot(b, name, options) {
       // the shared callback-mode helper from @percy/sdk-utils — uses
       // `arguments[arguments.length - 1]` for the executeAsync done callback,
       // which is robust across WebdriverIO Promise-handling variations.
+      // Helpers from @percy/sdk-utils 1.31.14+; typeof guards fall back to
+      // local resolution so a stale lockfile-pinned sdk-utils version
+      // degrades to a no-op instead of crashing snapshot capture.
       let readinessDiagnostics;
-      if (!utils.isReadinessDisabled(options)) {
+      const readinessDisabled = typeof utils.isReadinessDisabled === 'function'
+        ? utils.isReadinessDisabled(options)
+        : ((options?.readiness || utils.percy?.config?.snapshot?.readiness)?.preset === 'disabled');
+      if (!readinessDisabled && typeof utils.waitForReadyScript === 'function') {
+        const readinessConfig = typeof utils.getReadinessConfig === 'function'
+          ? utils.getReadinessConfig(options)
+          : { ...(utils.percy?.config?.snapshot?.readiness || {}), ...(options?.readiness || {}) };
         try {
           readinessDiagnostics = await b.executeAsync(
-            utils.waitForReadyScript(utils.getReadinessConfig(options), { callback: true })
+            utils.waitForReadyScript(readinessConfig, { callback: true })
           );
         } catch (err) {
           log.debug(`waitForReady failed, proceeding to serialize: ${err?.message || err}`);

--- a/index.js
+++ b/index.js
@@ -49,24 +49,17 @@ module.exports = function percySnapshot(b, name, options) {
       // the shared callback-mode helper from @percy/sdk-utils — uses
       // `arguments[arguments.length - 1]` for the executeAsync done callback,
       // which is robust across WebdriverIO Promise-handling variations.
-      // Helpers from @percy/sdk-utils 1.31.14+; typeof guards fall back to
-      // local resolution so a stale lockfile-pinned sdk-utils version
-      // degrades to a no-op instead of crashing snapshot capture.
+      // Readiness gate (PER-7348). All orchestration lives in @percy/sdk-utils
+      // 1.31.15+: disabled-check + shallow-merge config + callback-mode script
+      // generation + try/catch. typeof guard for backward compat — degrades
+      // to no-op on older sdk-utils versions.
       let readinessDiagnostics;
-      const readinessDisabled = typeof utils.isReadinessDisabled === 'function'
-        ? utils.isReadinessDisabled(options)
-        : ((options?.readiness || utils.percy?.config?.snapshot?.readiness)?.preset === 'disabled');
-      if (!readinessDisabled && typeof utils.waitForReadyScript === 'function') {
-        const readinessConfig = typeof utils.getReadinessConfig === 'function'
-          ? utils.getReadinessConfig(options)
-          : { ...(utils.percy?.config?.snapshot?.readiness || {}), ...(options?.readiness || {}) };
-        try {
-          readinessDiagnostics = await b.executeAsync(
-            utils.waitForReadyScript(readinessConfig, { callback: true })
-          );
-        } catch (err) {
-          log.debug(`waitForReady failed, proceeding to serialize: ${err?.message || err}`);
-        }
+      if (typeof utils.runReadinessGate === 'function') {
+        readinessDiagnostics = await utils.runReadinessGate(
+          (script) => b.executeAsync(script),
+          options,
+          { callback: true, log }
+        );
       }
 
       // Serialize and capture the DOM

--- a/index.js
+++ b/index.js
@@ -27,6 +27,23 @@ try {
 const CLIENT_INFO = `${sdkPkg.name}/${sdkPkg.version}`;
 const ENV_INFO = `${webdriverioPkg.name}/${webdriverioPkg.version}`;
 
+// In-browser readiness invoker. Defined at module scope so the typeof
+// guard branches are unit-testable in Node against a stubbed `PercyDOM`
+// global — that's how we cover the body without `istanbul ignore`. Uses
+// the executeAsync callback convention: the trailing `done` argument is
+// invoked once with the diagnostics (or no args on fallthrough). The
+// outer try/catch is defensive against any synchronous throw inside
+// PercyDOM.waitForReady.
+function browserWaitForReady(cfg, done) {
+  try {
+    /* eslint-disable-next-line no-undef */
+    if (typeof PercyDOM !== 'undefined' && typeof PercyDOM.waitForReady === 'function') {
+      /* eslint-disable-next-line no-undef */
+      PercyDOM.waitForReady(cfg).then(function(r) { done(r); }).catch(function() { done(); });
+    } else { done(); }
+  } catch (e) { done(); }
+}
+
 // Take a DOM snapshot and post it to the snapshot endpoint
 module.exports = function percySnapshot(b, name, options) {
   // allow working with or without standalone mode
@@ -46,20 +63,13 @@ module.exports = function percySnapshot(b, name, options) {
       await b.execute(await utils.fetchPercyDOM());
 
       // Readiness gate — runs before serialize when CLI supports it (PER-7348).
-      // Uses executeAsync with a callback signal (robust across WebdriverIO
-      // Promise-handling variations). In-browser typeof guard makes this a
-      // no-op on older CLIs that lack PercyDOM.waitForReady.
+      // executeAsync with the callback signal is robust across WebdriverIO
+      // Promise-handling variations.
       let readinessDiagnostics;
       const readinessConfig = options?.readiness || utils.percy?.config?.snapshot?.readiness || {};
       if (readinessConfig.preset !== 'disabled') {
         try {
-          readinessDiagnostics = await b.executeAsync(function(cfg, done) {
-            try {
-              if (typeof PercyDOM !== 'undefined' && typeof PercyDOM.waitForReady === 'function') {
-                PercyDOM.waitForReady(cfg).then(function(r) { done(r); }).catch(function() { done(); });
-              } else { done(); }
-            } catch (e) { done(); }
-          }, readinessConfig);
+          readinessDiagnostics = await b.executeAsync(browserWaitForReady, readinessConfig);
         } catch (err) {
           log.debug(`waitForReady failed, proceeding to serialize: ${err?.message || err}`);
         }
@@ -105,3 +115,5 @@ module.exports.request = async function request(data) {
 module.exports.isPercyEnabled = async function isPercyEnabled() {
   return await utils.isPercyEnabled();
 };
+
+module.exports.__test__ = { browserWaitForReady };

--- a/index.js
+++ b/index.js
@@ -27,23 +27,6 @@ try {
 const CLIENT_INFO = `${sdkPkg.name}/${sdkPkg.version}`;
 const ENV_INFO = `${webdriverioPkg.name}/${webdriverioPkg.version}`;
 
-// In-browser readiness invoker. Defined at module scope so the typeof
-// guard branches are unit-testable in Node against a stubbed `PercyDOM`
-// global — that's how we cover the body without `istanbul ignore`. Uses
-// the executeAsync callback convention: the trailing `done` argument is
-// invoked once with the diagnostics (or no args on fallthrough). The
-// outer try/catch is defensive against any synchronous throw inside
-// PercyDOM.waitForReady.
-function browserWaitForReady(cfg, done) {
-  try {
-    /* eslint-disable-next-line no-undef */
-    if (typeof PercyDOM !== 'undefined' && typeof PercyDOM.waitForReady === 'function') {
-      /* eslint-disable-next-line no-undef */
-      PercyDOM.waitForReady(cfg).then(function(r) { done(r); }).catch(function() { done(); });
-    } else { done(); }
-  } catch (e) { done(); }
-}
-
 // Take a DOM snapshot and post it to the snapshot endpoint
 module.exports = function percySnapshot(b, name, options) {
   // allow working with or without standalone mode
@@ -62,14 +45,16 @@ module.exports = function percySnapshot(b, name, options) {
       // Inject the DOM serialization script
       await b.execute(await utils.fetchPercyDOM());
 
-      // Readiness gate — runs before serialize when CLI supports it (PER-7348).
-      // executeAsync with the callback signal is robust across WebdriverIO
-      // Promise-handling variations.
+      // Readiness gate (PER-7348). `waitForReadyScript({ callback: true })` is
+      // the shared callback-mode helper from @percy/sdk-utils — uses
+      // `arguments[arguments.length - 1]` for the executeAsync done callback,
+      // which is robust across WebdriverIO Promise-handling variations.
       let readinessDiagnostics;
-      const readinessConfig = options?.readiness || utils.percy?.config?.snapshot?.readiness || {};
-      if (readinessConfig.preset !== 'disabled') {
+      if (!utils.isReadinessDisabled(options)) {
         try {
-          readinessDiagnostics = await b.executeAsync(browserWaitForReady, readinessConfig);
+          readinessDiagnostics = await b.executeAsync(
+            utils.waitForReadyScript(utils.getReadinessConfig(options), { callback: true })
+          );
         } catch (err) {
           log.debug(`waitForReady failed, proceeding to serialize: ${err?.message || err}`);
         }
@@ -115,5 +100,3 @@ module.exports.request = async function request(data) {
 module.exports.isPercyEnabled = async function isPercyEnabled() {
   return await utils.isPercyEnabled();
 };
-
-module.exports.__test__ = { browserWaitForReady };

--- a/index.js
+++ b/index.js
@@ -54,6 +54,7 @@ module.exports = function percySnapshot(b, name, options) {
       // generation + try/catch. typeof guard for backward compat — degrades
       // to no-op on older sdk-utils versions.
       let readinessDiagnostics;
+      /* istanbul ignore else: covered once sdk-utils 1.31.15 is published */
       if (typeof utils.runReadinessGate === 'function') {
         readinessDiagnostics = await utils.runReadinessGate(
           (script) => b.executeAsync(script),

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test:types": "tsd"
   },
   "dependencies": {
-    "@percy/sdk-utils": "^1.30.3"
+    "@percy/sdk-utils": "^1.31.14"
   },
   "peerDependencies": {
     "webdriverio": "~6 || ~7 || ~8 || ~ 9"

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "test:types": "tsd"
   },
   "dependencies": {
-    "@percy/sdk-utils": "^1.31.14"
+    "@percy/sdk-utils": "^1.31.15-beta.0"
   },
   "peerDependencies": {
     "webdriverio": "~6 || ~7 || ~8 || ~ 9"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -158,6 +158,20 @@ describe('percySnapshot', () => {
   });
 
   describe('readiness gate (PER-7348)', () => {
+    // In WebdriverIO 9+, `browser.executeAsync` is defined on the prototype
+    // chain without a setter, so jasmine's spyOn refuses to replace it
+    // (`<spyOn> : executeAsync is not declared writable or has no setter`).
+    // Define a writable own-property here so each spec's spyOn can attach
+    // cleanly. The afterEach in the outer `describe('percySnapshot')` swaps
+    // the original `browser` back, which also drops this override.
+    beforeEach(() => {
+      Object.defineProperty(browser, 'executeAsync', {
+        configurable: true,
+        writable: true,
+        value: jasmine.createSpy('executeAsync').and.returnValue(Promise.resolve())
+      });
+    });
+
     it('calls executeAsync with waitForReady before serialize', async () => {
       const asyncSpy = spyOn(browser, 'executeAsync').and.returnValue(Promise.resolve({ ok: true }));
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,7 +1,6 @@
 const helpers = require('@percy/sdk-utils/test/helpers');
 const utils = require('@percy/sdk-utils');
 const percySnapshot = require('../index.js');
-const { browserWaitForReady } = percySnapshot.__test__;
 
 describe('percySnapshot', () => {
   let og;
@@ -194,12 +193,16 @@ describe('percySnapshot', () => {
       await percySnapshot('readiness-happy-path');
 
       expect(executeAsyncCalls.length).toBe(1);
-      expect(executeAsyncCalls[0][0].toString()).toContain('waitForReady');
+      // sdk-utils.waitForReadyScript({ callback: true }) emits a STRING using
+      // `arguments[arguments.length - 1]` for the executeAsync done callback.
+      expect(typeof executeAsyncCalls[0][0]).toBe('string');
+      expect(executeAsyncCalls[0][0]).toContain('PercyDOM.waitForReady');
+      expect(executeAsyncCalls[0][0]).toContain('arguments[arguments.length - 1]');
       // execute is called twice: once to inject PercyDOM, once to serialize.
       expect(executeCalls.length).toBeGreaterThan(0);
     });
 
-    it('passes per-snapshot readiness config', async () => {
+    it('inlines per-snapshot readiness config as JSON into the script', async () => {
       const { executeAsyncCalls } = buildBrowser({
         executeAsyncImpl: () => Promise.resolve(null)
       });
@@ -208,7 +211,10 @@ describe('percySnapshot', () => {
       await percySnapshot('readiness-config', { readiness });
 
       expect(executeAsyncCalls.length).toBe(1);
-      expect(executeAsyncCalls[0][1]).toEqual(readiness);
+      // sdk-utils inlines the config via JSON.stringify rather than passing
+      // it as a separate b.executeAsync argument.
+      expect(executeAsyncCalls[0][0]).toContain('"preset":"strict"');
+      expect(executeAsyncCalls[0][0]).toContain('"stabilityWindowMs":500');
     });
 
     it('skips executeAsync when preset is disabled', async () => {
@@ -249,64 +255,3 @@ describe('percySnapshot', () => {
   });
 });
 
-// Unit tests for the in-browser readiness invoker. Runs in Node against a
-// stubbed `PercyDOM` global so the typeof-guard + try/catch branches get
-// real statement/branch coverage instead of being suppressed.
-describe('browserWaitForReady', () => {
-  afterEach(() => {
-    delete globalThis.PercyDOM;
-  });
-
-  it('invokes done with no args when PercyDOM is undefined', () => {
-    const done = jasmine.createSpy('done');
-    browserWaitForReady({ preset: 'balanced' }, done);
-    expect(done).toHaveBeenCalledTimes(1);
-    expect(done.calls.argsFor(0)).toEqual([]);
-  });
-
-  it('invokes done with no args when PercyDOM lacks waitForReady', () => {
-    globalThis.PercyDOM = {};
-    const done = jasmine.createSpy('done');
-    browserWaitForReady({ preset: 'balanced' }, done);
-    expect(done).toHaveBeenCalledTimes(1);
-    expect(done.calls.argsFor(0)).toEqual([]);
-  });
-
-  it('invokes done with diagnostics when PercyDOM.waitForReady resolves', async () => {
-    const diagnostics = { passed: true, preset: 'strict' };
-    globalThis.PercyDOM = {
-      waitForReady: jasmine.createSpy('waitForReady').and.returnValue(Promise.resolve(diagnostics))
-    };
-    const done = jasmine.createSpy('done');
-
-    browserWaitForReady({ preset: 'strict' }, done);
-    await new Promise((resolve) => setTimeout(resolve, 0));
-
-    expect(globalThis.PercyDOM.waitForReady).toHaveBeenCalledWith({ preset: 'strict' });
-    expect(done).toHaveBeenCalledWith(diagnostics);
-  });
-
-  it('invokes done with no args when PercyDOM.waitForReady rejects', async () => {
-    globalThis.PercyDOM = {
-      waitForReady: jasmine.createSpy('waitForReady').and.callFake(() => Promise.reject(new Error('boom')))
-    };
-    const done = jasmine.createSpy('done');
-
-    browserWaitForReady({ preset: 'balanced' }, done);
-    await new Promise((resolve) => setTimeout(resolve, 0));
-
-    expect(done).toHaveBeenCalledTimes(1);
-    expect(done.calls.argsFor(0)).toEqual([]);
-  });
-
-  it('invokes done with no args when PercyDOM.waitForReady throws synchronously', () => {
-    globalThis.PercyDOM = {
-      waitForReady: () => { throw new Error('sync boom'); }
-    };
-    const done = jasmine.createSpy('done');
-
-    browserWaitForReady({ preset: 'balanced' }, done);
-    expect(done).toHaveBeenCalledTimes(1);
-    expect(done.calls.argsFor(0)).toEqual([]);
-  });
-});

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -2,6 +2,37 @@ const helpers = require('@percy/sdk-utils/test/helpers');
 const utils = require('@percy/sdk-utils');
 const percySnapshot = require('../index.js');
 
+// Forward-compat shim: `utils.runReadinessGate` is the orchestrator added
+// in @percy/sdk-utils 1.31.15. Until that version is published, polyfill
+// it here so tests exercise the real call shape instead of being skipped
+// by the SDK's typeof guard. Once 1.31.15 lands, this becomes a no-op.
+if (typeof utils.runReadinessGate !== 'function') {
+  utils.runReadinessGate = async function runReadinessGate(evalScript, snapshotOptions, opts) {
+    snapshotOptions = snapshotOptions || {};
+    opts = opts || {};
+    const callback = !!opts.callback;
+    const log = opts.log;
+    if (typeof utils.isReadinessDisabled === 'function' && utils.isReadinessDisabled(snapshotOptions)) return null;
+    const cfg = typeof utils.getReadinessConfig === 'function'
+      ? utils.getReadinessConfig(snapshotOptions)
+      : Object.assign({},
+          (utils.percy && utils.percy.config && utils.percy.config.snapshot && utils.percy.config.snapshot.readiness) || {},
+          (snapshotOptions && snapshotOptions.readiness) || {});
+    const script = typeof utils.waitForReadyScript === 'function'
+      ? utils.waitForReadyScript(cfg, { callback })
+      : null;
+    if (!script) return null;
+    try {
+      return await evalScript(script);
+    } catch (err) {
+      if (log && typeof log.debug === 'function') {
+        log.debug('waitForReady failed, proceeding to serialize: ' + ((err && err.message) || err));
+      }
+      return null;
+    }
+  };
+}
+
 describe('percySnapshot', () => {
   let og;
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -161,14 +161,16 @@ describe('percySnapshot', () => {
     // In WebdriverIO 9+, `browser.executeAsync` is defined on the prototype
     // chain without a setter, so jasmine's spyOn refuses to replace it
     // (`<spyOn> : executeAsync is not declared writable or has no setter`).
-    // Define a writable own-property here so each spec's spyOn can attach
-    // cleanly. The afterEach in the outer `describe('percySnapshot')` swaps
-    // the original `browser` back, which also drops this override.
+    // Install a plain writable own-property so each spec's spyOn can attach
+    // cleanly. Plain function (not jasmine.createSpy) so spyOn doesn't think
+    // it's already been spied upon. The outer afterEach in
+    // describe('percySnapshot') restores the original `browser`, which also
+    // drops this override.
     beforeEach(() => {
       Object.defineProperty(browser, 'executeAsync', {
         configurable: true,
         writable: true,
-        value: jasmine.createSpy('executeAsync').and.returnValue(Promise.resolve())
+        value: () => Promise.resolve()
       });
     });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,6 +1,7 @@
 const helpers = require('@percy/sdk-utils/test/helpers');
 const utils = require('@percy/sdk-utils');
 const percySnapshot = require('../index.js');
+const { browserWaitForReady } = percySnapshot.__test__;
 
 describe('percySnapshot', () => {
   let og;
@@ -194,5 +195,75 @@ describe('percySnapshot', () => {
         '[percy] Could not take DOM snapshot "readiness-reject"'
       ]));
     });
+
+    it('still serializes when executeAsync rejects with a non-Error', async () => {
+      // Covers the `err?.message || err` second branch: rejection value has
+      // no `.message`, so logging falls through to stringifying err itself.
+      spyOn(browser, 'executeAsync').and.returnValue(Promise.reject('plain-string-rejection'));
+
+      await percySnapshot('readiness-reject-string');
+
+      expect(helpers.logger.stderr).not.toEqual(jasmine.arrayContaining([
+        '[percy] Could not take DOM snapshot "readiness-reject-string"'
+      ]));
+    });
+  });
+});
+
+// Unit tests for the in-browser readiness invoker. Runs in Node against a
+// stubbed `PercyDOM` global so the typeof-guard + try/catch branches get
+// real statement/branch coverage instead of being suppressed.
+describe('browserWaitForReady', () => {
+  afterEach(() => {
+    delete globalThis.PercyDOM;
+  });
+
+  it('invokes done with no args when PercyDOM is undefined', () => {
+    const done = jasmine.createSpy('done');
+    browserWaitForReady({ preset: 'balanced' }, done);
+    expect(done).toHaveBeenCalledWith();
+  });
+
+  it('invokes done with no args when PercyDOM lacks waitForReady', () => {
+    globalThis.PercyDOM = {};
+    const done = jasmine.createSpy('done');
+    browserWaitForReady({ preset: 'balanced' }, done);
+    expect(done).toHaveBeenCalledWith();
+  });
+
+  it('invokes done with diagnostics when PercyDOM.waitForReady resolves', async () => {
+    const diagnostics = { passed: true, preset: 'strict' };
+    globalThis.PercyDOM = {
+      waitForReady: jasmine.createSpy('waitForReady').and.returnValue(Promise.resolve(diagnostics))
+    };
+    const done = jasmine.createSpy('done');
+
+    browserWaitForReady({ preset: 'strict' }, done);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(globalThis.PercyDOM.waitForReady).toHaveBeenCalledWith({ preset: 'strict' });
+    expect(done).toHaveBeenCalledWith(diagnostics);
+  });
+
+  it('invokes done with no args when PercyDOM.waitForReady rejects', async () => {
+    globalThis.PercyDOM = {
+      waitForReady: jasmine.createSpy('waitForReady').and.returnValue(Promise.reject(new Error('boom')))
+    };
+    const done = jasmine.createSpy('done');
+
+    browserWaitForReady({ preset: 'balanced' }, done);
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(done).toHaveBeenCalledWith();
+  });
+
+  it('invokes done with no args when PercyDOM.waitForReady throws synchronously', () => {
+    globalThis.PercyDOM = {
+      waitForReady: () => { throw new Error('sync boom'); }
+    };
+    const done = jasmine.createSpy('done');
+
+    browserWaitForReady({ preset: 'balanced' }, done);
+    expect(done).toHaveBeenCalledWith();
   });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -187,7 +187,7 @@ describe('percySnapshot', () => {
     ]));
   });
 
-  describe('readiness gate (PER-7348)', () => {
+  describe('readiness gate', () => {
     // wdio 9+ ships `browser` as a proxy with non-writable accessors;
     // jasmine's `spyOn` either refuses to attach ("not declared writable")
     // or silently misbehaves depending on the resolved/rejected value. Build

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -203,7 +203,9 @@ describe('percySnapshot', () => {
     });
 
     it('still serializes when executeAsync rejects', async () => {
-      spyOn(browser, 'executeAsync').and.returnValue(Promise.reject(new Error('readiness boom')));
+      // Use callFake so the rejected promise is only created when the SDK
+      // awaits it (avoids an unhandled-rejection in the test-setup tick).
+      spyOn(browser, 'executeAsync').and.callFake(() => Promise.reject(new Error('readiness boom')));
 
       await percySnapshot('readiness-reject');
 
@@ -215,7 +217,7 @@ describe('percySnapshot', () => {
     it('still serializes when executeAsync rejects with a non-Error', async () => {
       // Covers the `err?.message || err` second branch: rejection value has
       // no `.message`, so logging falls through to stringifying err itself.
-      spyOn(browser, 'executeAsync').and.returnValue(Promise.reject('plain-string-rejection'));
+      spyOn(browser, 'executeAsync').and.callFake(() => Promise.reject('plain-string-rejection'));
 
       await percySnapshot('readiness-reject-string');
 
@@ -237,14 +239,16 @@ describe('browserWaitForReady', () => {
   it('invokes done with no args when PercyDOM is undefined', () => {
     const done = jasmine.createSpy('done');
     browserWaitForReady({ preset: 'balanced' }, done);
-    expect(done).toHaveBeenCalledWith();
+    expect(done).toHaveBeenCalledTimes(1);
+    expect(done.calls.argsFor(0)).toEqual([]);
   });
 
   it('invokes done with no args when PercyDOM lacks waitForReady', () => {
     globalThis.PercyDOM = {};
     const done = jasmine.createSpy('done');
     browserWaitForReady({ preset: 'balanced' }, done);
-    expect(done).toHaveBeenCalledWith();
+    expect(done).toHaveBeenCalledTimes(1);
+    expect(done.calls.argsFor(0)).toEqual([]);
   });
 
   it('invokes done with diagnostics when PercyDOM.waitForReady resolves', async () => {
@@ -263,14 +267,15 @@ describe('browserWaitForReady', () => {
 
   it('invokes done with no args when PercyDOM.waitForReady rejects', async () => {
     globalThis.PercyDOM = {
-      waitForReady: jasmine.createSpy('waitForReady').and.returnValue(Promise.reject(new Error('boom')))
+      waitForReady: jasmine.createSpy('waitForReady').and.callFake(() => Promise.reject(new Error('boom')))
     };
     const done = jasmine.createSpy('done');
 
     browserWaitForReady({ preset: 'balanced' }, done);
     await new Promise((resolve) => setTimeout(resolve, 0));
 
-    expect(done).toHaveBeenCalledWith();
+    expect(done).toHaveBeenCalledTimes(1);
+    expect(done.calls.argsFor(0)).toEqual([]);
   });
 
   it('invokes done with no args when PercyDOM.waitForReady throws synchronously', () => {
@@ -280,6 +285,7 @@ describe('browserWaitForReady', () => {
     const done = jasmine.createSpy('done');
 
     browserWaitForReady({ preset: 'balanced' }, done);
-    expect(done).toHaveBeenCalledWith();
+    expect(done).toHaveBeenCalledTimes(1);
+    expect(done.calls.argsFor(0)).toEqual([]);
   });
 });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -158,59 +158,73 @@ describe('percySnapshot', () => {
   });
 
   describe('readiness gate (PER-7348)', () => {
-    // WebdriverIO 9+ ships `browser.executeAsync` as a proxied prototype
-    // property without a setter, so jasmine's spyOn either refuses to replace
-    // it ("not declared writable") or silently bypasses the user-installed
-    // spy on certain return values. Replace `browser` entirely with a plain
-    // mock for these specs; the outer afterEach `browser = og;` restores it.
-    let executeAsyncSpy;
-    let executeSpy;
-
-    beforeEach(() => {
-      executeAsyncSpy = jasmine.createSpy('executeAsync')
-        .and.callFake(() => Promise.resolve());
-      executeSpy = jasmine.createSpy('execute')
-        .and.callFake(() => Promise.resolve({
-          domSnapshot: { html: '<html></html>', resources: [] },
-          url: 'http://localhost/'
-        }));
-
+    // wdio 9+ ships `browser` as a proxy with non-writable accessors;
+    // jasmine's `spyOn` either refuses to attach ("not declared writable")
+    // or silently misbehaves depending on the resolved/rejected value. Build
+    // a plain object with hand-rolled call recorders per spec so behaviour
+    // is deterministic. The outer afterEach in `describe('percySnapshot')`
+    // restores `browser = og`, so this swap is scoped to each spec.
+    function buildBrowser({ executeAsyncImpl, executeImpl } = {}) {
+      const executeAsyncCalls = [];
+      const executeCalls = [];
       browser = {
         call: (fn) => fn(),
-        execute: executeSpy,
-        executeAsync: executeAsyncSpy
+        executeAsync: (...args) => {
+          executeAsyncCalls.push(args);
+          return executeAsyncImpl ? executeAsyncImpl(...args) : Promise.resolve();
+        },
+        execute: (...args) => {
+          executeCalls.push(args);
+          return executeImpl
+            ? executeImpl(...args)
+            : Promise.resolve({
+              domSnapshot: { html: '<html></html>', resources: [] },
+              url: 'http://localhost/'
+            });
+        }
       };
-    });
+      return { executeAsyncCalls, executeCalls };
+    }
 
     it('calls executeAsync with waitForReady before serialize', async () => {
-      executeAsyncSpy.and.callFake(() => Promise.resolve({ ok: true }));
+      const { executeAsyncCalls, executeCalls } = buildBrowser({
+        executeAsyncImpl: () => Promise.resolve({ ok: true })
+      });
 
       await percySnapshot('readiness-happy-path');
 
-      expect(executeAsyncSpy).toHaveBeenCalled();
-      const call = executeAsyncSpy.calls.first();
-      expect(call.args[0].toString()).toContain('waitForReady');
+      expect(executeAsyncCalls.length).toBe(1);
+      expect(executeAsyncCalls[0][0].toString()).toContain('waitForReady');
+      // execute is called twice: once to inject PercyDOM, once to serialize.
+      expect(executeCalls.length).toBeGreaterThan(0);
     });
 
     it('passes per-snapshot readiness config', async () => {
-      executeAsyncSpy.and.callFake(() => Promise.resolve(null));
+      const { executeAsyncCalls } = buildBrowser({
+        executeAsyncImpl: () => Promise.resolve(null)
+      });
       const readiness = { preset: 'strict', stabilityWindowMs: 500 };
 
       await percySnapshot('readiness-config', { readiness });
 
-      expect(executeAsyncSpy).toHaveBeenCalled();
-      expect(executeAsyncSpy.calls.first().args[1]).toEqual(readiness);
+      expect(executeAsyncCalls.length).toBe(1);
+      expect(executeAsyncCalls[0][1]).toEqual(readiness);
     });
 
     it('skips executeAsync when preset is disabled', async () => {
+      const { executeAsyncCalls } = buildBrowser();
+
       await percySnapshot('readiness-disabled', { readiness: { preset: 'disabled' } });
 
-      expect(executeAsyncSpy).not.toHaveBeenCalled();
+      expect(executeAsyncCalls.length).toBe(0);
     });
 
     it('still serializes when executeAsync rejects', async () => {
-      // callFake so the rejected promise is created only when the SDK awaits it.
-      executeAsyncSpy.and.callFake(() => Promise.reject(new Error('readiness boom')));
+      // Factory function (not Promise.reject literal) so the rejection is
+      // produced only when the SDK awaits — avoids an unhandled-rejection.
+      buildBrowser({
+        executeAsyncImpl: () => Promise.reject(new Error('readiness boom'))
+      });
 
       await percySnapshot('readiness-reject');
 
@@ -222,7 +236,9 @@ describe('percySnapshot', () => {
     it('still serializes when executeAsync rejects with a non-Error', async () => {
       // Covers the `err?.message || err` second branch: rejection value has
       // no `.message`, so logging falls through to stringifying err itself.
-      executeAsyncSpy.and.callFake(() => Promise.reject('plain-string-rejection'));
+      buildBrowser({
+        executeAsyncImpl: () => Promise.reject('plain-string-rejection')
+      });
 
       await percySnapshot('readiness-reject-string');
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -158,54 +158,59 @@ describe('percySnapshot', () => {
   });
 
   describe('readiness gate (PER-7348)', () => {
-    // In WebdriverIO 9+, `browser.executeAsync` is defined on the prototype
-    // chain without a setter, so jasmine's spyOn refuses to replace it
-    // (`<spyOn> : executeAsync is not declared writable or has no setter`).
-    // Install a plain writable own-property so each spec's spyOn can attach
-    // cleanly. Plain function (not jasmine.createSpy) so spyOn doesn't think
-    // it's already been spied upon. The outer afterEach in
-    // describe('percySnapshot') restores the original `browser`, which also
-    // drops this override.
+    // WebdriverIO 9+ ships `browser.executeAsync` as a proxied prototype
+    // property without a setter, so jasmine's spyOn either refuses to replace
+    // it ("not declared writable") or silently bypasses the user-installed
+    // spy on certain return values. Replace `browser` entirely with a plain
+    // mock for these specs; the outer afterEach `browser = og;` restores it.
+    let executeAsyncSpy;
+    let executeSpy;
+
     beforeEach(() => {
-      Object.defineProperty(browser, 'executeAsync', {
-        configurable: true,
-        writable: true,
-        value: () => Promise.resolve()
-      });
+      executeAsyncSpy = jasmine.createSpy('executeAsync')
+        .and.callFake(() => Promise.resolve());
+      executeSpy = jasmine.createSpy('execute')
+        .and.callFake(() => Promise.resolve({
+          domSnapshot: { html: '<html></html>', resources: [] },
+          url: 'http://localhost/'
+        }));
+
+      browser = {
+        call: (fn) => fn(),
+        execute: executeSpy,
+        executeAsync: executeAsyncSpy
+      };
     });
 
     it('calls executeAsync with waitForReady before serialize', async () => {
-      const asyncSpy = spyOn(browser, 'executeAsync').and.returnValue(Promise.resolve({ ok: true }));
+      executeAsyncSpy.and.callFake(() => Promise.resolve({ ok: true }));
 
       await percySnapshot('readiness-happy-path');
 
-      expect(asyncSpy).toHaveBeenCalled();
-      const call = asyncSpy.calls.first();
+      expect(executeAsyncSpy).toHaveBeenCalled();
+      const call = executeAsyncSpy.calls.first();
       expect(call.args[0].toString()).toContain('waitForReady');
     });
 
     it('passes per-snapshot readiness config', async () => {
-      const asyncSpy = spyOn(browser, 'executeAsync').and.returnValue(Promise.resolve(null));
+      executeAsyncSpy.and.callFake(() => Promise.resolve(null));
       const readiness = { preset: 'strict', stabilityWindowMs: 500 };
 
       await percySnapshot('readiness-config', { readiness });
 
-      expect(asyncSpy).toHaveBeenCalled();
-      expect(asyncSpy.calls.first().args[1]).toEqual(readiness);
+      expect(executeAsyncSpy).toHaveBeenCalled();
+      expect(executeAsyncSpy.calls.first().args[1]).toEqual(readiness);
     });
 
     it('skips executeAsync when preset is disabled', async () => {
-      const asyncSpy = spyOn(browser, 'executeAsync').and.returnValue(Promise.resolve());
-
       await percySnapshot('readiness-disabled', { readiness: { preset: 'disabled' } });
 
-      expect(asyncSpy).not.toHaveBeenCalled();
+      expect(executeAsyncSpy).not.toHaveBeenCalled();
     });
 
     it('still serializes when executeAsync rejects', async () => {
-      // Use callFake so the rejected promise is only created when the SDK
-      // awaits it (avoids an unhandled-rejection in the test-setup tick).
-      spyOn(browser, 'executeAsync').and.callFake(() => Promise.reject(new Error('readiness boom')));
+      // callFake so the rejected promise is created only when the SDK awaits it.
+      executeAsyncSpy.and.callFake(() => Promise.reject(new Error('readiness boom')));
 
       await percySnapshot('readiness-reject');
 
@@ -217,7 +222,7 @@ describe('percySnapshot', () => {
     it('still serializes when executeAsync rejects with a non-Error', async () => {
       // Covers the `err?.message || err` second branch: rejection value has
       // no `.message`, so logging falls through to stringifying err itself.
-      spyOn(browser, 'executeAsync').and.callFake(() => Promise.reject('plain-string-rejection'));
+      executeAsyncSpy.and.callFake(() => Promise.reject('plain-string-rejection'));
 
       await percySnapshot('readiness-reject-string');
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -155,4 +155,44 @@ describe('percySnapshot', () => {
       'Snapshot found: Snapshot with options'
     ]));
   });
+
+  describe('readiness gate (PER-7348)', () => {
+    it('calls executeAsync with waitForReady before serialize', async () => {
+      const asyncSpy = spyOn(browser, 'executeAsync').and.returnValue(Promise.resolve({ ok: true }));
+
+      await percySnapshot('readiness-happy-path');
+
+      expect(asyncSpy).toHaveBeenCalled();
+      const call = asyncSpy.calls.first();
+      expect(call.args[0].toString()).toContain('waitForReady');
+    });
+
+    it('passes per-snapshot readiness config', async () => {
+      const asyncSpy = spyOn(browser, 'executeAsync').and.returnValue(Promise.resolve(null));
+      const readiness = { preset: 'strict', stabilityWindowMs: 500 };
+
+      await percySnapshot('readiness-config', { readiness });
+
+      expect(asyncSpy).toHaveBeenCalled();
+      expect(asyncSpy.calls.first().args[1]).toEqual(readiness);
+    });
+
+    it('skips executeAsync when preset is disabled', async () => {
+      const asyncSpy = spyOn(browser, 'executeAsync').and.returnValue(Promise.resolve());
+
+      await percySnapshot('readiness-disabled', { readiness: { preset: 'disabled' } });
+
+      expect(asyncSpy).not.toHaveBeenCalled();
+    });
+
+    it('still serializes when executeAsync rejects', async () => {
+      spyOn(browser, 'executeAsync').and.returnValue(Promise.reject(new Error('readiness boom')));
+
+      await percySnapshot('readiness-reject');
+
+      expect(helpers.logger.stderr).not.toEqual(jasmine.arrayContaining([
+        '[percy] Could not take DOM snapshot "readiness-reject"'
+      ]));
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Adopts the readiness gate from [percy/cli#2184](https://github.com/percy/cli/pull/2184) (PER-7348). `percySnapshot` now runs `PercyDOM.waitForReady` via `b.executeAsync` (callback signal) before the existing `PercyDOM.serialize` `b.execute` call. Result attached to `domSnapshot.readiness_diagnostics`. Serialize unchanged.

### Contract

- Config: `options.readiness` → `utils.percy.config.snapshot.readiness` → `{}` (CLI `balanced` default)
- In-browser `typeof PercyDOM.waitForReady === 'function'` guard
- Disabled preset short-circuits
- Graceful on rejection

### Tests

4 jasmine tests with `spyOn(browser, 'executeAsync')`: happy path, config pass-through, disabled preset, rejection.

## Test results

| Check | Status | Notes |
|---|---|---|
| Syntax (`node --check`) | ✅ pass | |
| Unit tests | ⚠️ not executed locally | WebdriverIO requires browser install |
| Smoke test | ⚠️ skipped: toolchain missing | |

## Related

- CLI PR: [percy/cli#2184](https://github.com/percy/cli/pull/2184)