### PR TITLE
chore: release 3.3.3-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@percy/webdriverio",
   "description": "WebdriverIO client library for visual testing with Percy",
-  "version": "3.3.3-beta.0",
+  "version": "3.3.3-beta.1",
   "license": "MIT",
   "author": "Perceptual Inc.",
   "repository": "https://github.com/percy/percy-webdriverio",


### PR DESCRIPTION
## Summary
Beta version bump: `3.3.3-beta.0` → `3.3.3-beta.1`.

Includes the latest changes on master since the previous beta release, notably:
- feat: add cross-origin iframe capture (incl. nested up to depth 10) (#1441)
- Add supply-chain hardened .npmrc (PER-8327) (#1456)

## Changes
- Bump `version` in `package.json` to `3.3.3-beta.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)