### PR TITLE
chore: release 3.3.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@percy/webdriverio",
   "description": "WebdriverIO client library for visual testing with Percy",
-  "version": "3.3.3-beta.2",
+  "version": "3.3.3",
   "license": "MIT",
   "author": "Perceptual Inc.",
   "repository": "https://github.com/percy/percy-webdriverio",


### PR DESCRIPTION
Promotes the PER-8053 config-merge work from `3.3.3-beta.2` to stable `3.3.3`. Config is deep-merged into serializeDOM (per-call priority); verified via the cross-SDK sanity sweep.

Note: a pre-staged **draft** `v3.3.3` release exists (no git tag yet) — publish/replace it at release time.